### PR TITLE
feat: Arduino UNO R4 WiFi / Nano 33 IoT/ MKR WiFi 1010 support added

### DIFF
--- a/.github/workflows/build-arduino-boards.yml
+++ b/.github/workflows/build-arduino-boards.yml
@@ -37,9 +37,6 @@ jobs:
           - examples/Thermostat
           - examples/TV
           - examples/AirQualitySensor/AirQualitySensor
-          - examples/temperaturesensor/DHT22
-          - examples/temperaturesensor/AHT10
-          - examples/temperaturesensor/HTU21D
         board:
           - fqbn: arduino:renesas_uno:unor4wifi
             platform: arduino:renesas_uno

--- a/.github/workflows/build-arduino-boards.yml
+++ b/.github/workflows/build-arduino-boards.yml
@@ -1,4 +1,4 @@
-name: Build for ESP8266 and ESP32
+name: Build for Arduino UNO R4 WiFi, Nano 33 IoT, MKR WiFi 1010
 on:
   workflow_dispatch:
 
@@ -36,15 +36,20 @@ jobs:
           - examples/Switch/Switch
           - examples/Thermostat
           - examples/TV
-          - examples/OTAUpdate
-          - examples/Health
-          - examples/Settings/MultiWiFi
           - examples/AirQualitySensor/AirQualitySensor
+          - examples/temperaturesensor/DHT22
+          - examples/temperaturesensor/AHT10
+          - examples/temperaturesensor/HTU21D
         board:
-          - fqbn: esp8266:esp8266:nodemcuv2
-            platform: esp8266:esp8266
-          - fqbn: esp32:esp32:esp32
-            platform: esp32:esp32
+          - fqbn: arduino:renesas_uno:unor4wifi
+            platform: arduino:renesas_uno
+            name: UNO_R4_WiFi
+          - fqbn: arduino:samd:nano_33_iot
+            platform: arduino:samd
+            name: Nano_33_IoT
+          - fqbn: arduino:samd:mkrwifi1010
+            platform: arduino:samd
+            name: MKR_WiFi_1010
 
     steps:
       - name: Checkout repository
@@ -56,8 +61,6 @@ jobs:
       - name: Install board platforms
         run: |
           arduino-cli config init
-          arduino-cli config add board_manager.additional_urls https://arduino.esp8266.com/stable/package_esp8266com_index.json
-          arduino-cli config add board_manager.additional_urls https://espressif.github.io/arduino-esp32/package_esp32_index.json
           arduino-cli core update-index
           arduino-cli core install ${{ matrix.board.platform }}
 
@@ -65,6 +68,23 @@ jobs:
         run: |
           arduino-cli lib install "ArduinoJson"
           arduino-cli lib install "WebSockets"
+          # WiFiNINA required for SAMD boards
+          if [[ "${{ matrix.board.platform }}" == "arduino:samd" ]]; then
+            arduino-cli lib install "WiFiNINA"
+          fi
+          # DHT sensor library for temperature examples
+          if [[ "${{ matrix.example }}" == *"DHT22"* ]]; then
+            arduino-cli lib install "DHT sensor library"
+            arduino-cli lib install "Adafruit Unified Sensor"
+          fi
+          # AHT10 library for temperature examples
+          if [[ "${{ matrix.example }}" == *"AHT10"* ]]; then
+            arduino-cli lib install "Adafruit AHTX0"
+          fi
+          # HTU21D library for temperature examples
+          if [[ "${{ matrix.example }}" == *"HTU21D"* ]]; then
+            arduino-cli lib install "Adafruit HTU21DF Library"
+          fi
 
       - name: Link library to Arduino libraries folder
         run: |

--- a/.github/workflows/build-esp8266-esp32.yml
+++ b/.github/workflows/build-esp8266-esp32.yml
@@ -1,4 +1,4 @@
-name: Build for ESP8266 and ESP32
+name: Build for ESP8266, ESP32, and Arduino Boards
 on:
   workflow_dispatch:
 
@@ -43,8 +43,19 @@ jobs:
         board:
           - fqbn: esp8266:esp8266:nodemcuv2
             platform: esp8266:esp8266
+            needs_wifinina: false
           - fqbn: esp32:esp32:esp32
             platform: esp32:esp32
+            needs_wifinina: false
+          - fqbn: arduino:renesas_uno:unor4wifi
+            platform: arduino:renesas_uno
+            needs_wifinina: false
+          - fqbn: arduino:samd:nano_33_iot
+            platform: arduino:samd
+            needs_wifinina: true
+          - fqbn: arduino:samd:mkrwifi1010
+            platform: arduino:samd
+            needs_wifinina: true
 
     steps:
       - name: Checkout repository
@@ -65,6 +76,9 @@ jobs:
         run: |
           arduino-cli lib install "ArduinoJson"
           arduino-cli lib install "WebSockets"
+          if [ "${{ matrix.board.needs_wifinina }}" = "true" ]; then
+            arduino-cli lib install "WiFiNINA"
+          fi
 
       - name: Link library to Arduino libraries folder
         run: |

--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
-# SinricPro (ESP8266 / ESP32 / RP2040)
+# SinricPro (ESP8266 / ESP32 / RP2040 / Arduino UNO R4 WiFi / Arduino Nano 33 IoT / MKR WiFi 1010)
 [![arduino-library-badge](https://www.ardu-badge.com/badge/SinricPro.svg?)](https://www.arduino.cc/reference/en/libraries/sinricpro) [![PlatformIO Registry](https://badges.registry.platformio.org/packages/sinricpro/library/SinricPro.svg)](https://registry.platformio.org/libraries/sinricpro/SinricPro)
 
 [![Platform ESP8266](https://img.shields.io/badge/Platform-Espressif8266-orange)](#) [![Platform ESP32](https://img.shields.io/badge/Platform-Espressif32-orange)](#)
 [![Raspberry Pi RP2040](https://img.shields.io/badge/Platform-Raspberry_Pi_RP2040-orange)](#)
+[![Arduino UNO R4](https://img.shields.io/badge/Platform-Arduino_UNO_R4_WiFi-orange)](#)
+[![Arduino Nano 33 IoT](https://img.shields.io/badge/Platform-Arduino_Nano_33_IoT-orange)](#)
+[![MKR WiFi 1010](https://img.shields.io/badge/Platform-MKR_WiFi_1010-orange)](#)
 
 [![Framework](https://img.shields.io/badge/Framework-Arduino-blue)](https://www.arduino.cc/)
 
@@ -42,6 +45,33 @@
 - Arduino core 3.x
 - [ArduinoJson](https://github.com/bblanchon/ArduinoJson) by Benoit Blanchon (minimum Version 7.0.3)
 - [WebSockets](https://github.com/Links2004/arduinoWebSockets) by Markus Sattler (minimum Version 2.4.0)
+- [WiFiNINA](https://github.com/arduino-libraries/WiFiNINA) (for Arduino Nano 33 IoT and MKR WiFi 1010 only)
+
+---
+
+## Supported Boards
+
+### Fully Supported (All Features Including Camera)
+- **ESP8266** (all variants) - WiFi with SSL/TLS support
+- **ESP32** (all variants) - WiFi with SSL/TLS support
+- **Raspberry Pi Pico W (RP2040)** - WiFi with SSL/TLS support
+
+### Supported (No Camera Features)
+- **Arduino Nano 33 IoT** - WiFiNINA library, SSL/TLS enabled
+- **Arduino MKR WiFi 1010** - WiFiNINA library, SSL/TLS enabled
+- **Arduino UNO R4 WiFi** - WiFiS3 library, **no SSL/TLS support**
+
+All boards support switches, lights, sensors, thermostats, and other non-camera device types.
+
+### WiFi Library Requirements
+| Board | WiFi Library | SSL/TLS | Included |
+|-------|-------------|---------|----------|
+| ESP8266 | ESP8266WiFi.h | ✓ | ✓ |
+| ESP32 | WiFi.h | ✓ | ✓ |
+| RP2040 | WiFi.h | ✓ | ✓ |
+| Nano 33 IoT | WiFiNINA.h | ✓ | Install separately |
+| MKR WiFi 1010 | WiFiNINA.h | ✓ | Install separately |
+| UNO R4 WiFi | WiFiS3.h | ✗ | ✓ |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@
 
 [![Build](https://github.com/sinricpro/esp8266-esp32-sdk/actions/workflows/build-rpipicow.yml/badge.svg)](https://github.com/sinricpro/esp8266-esp32-sdk/actions/workflows/build-rpipicow.yml)
 
+[![Build](https://github.com/sinricpro/esp8266-esp32-sdk/actions/workflows/build-arduino-boards.yml/badge.svg)](https://github.com/sinricpro/esp8266-esp32-sdk/actions/workflows/build-arduino-boards.yml)
+
 [![Discord](https://img.shields.io/badge/discord-%23esp8266--esp32-blue.svg)](https://discord.gg/rq9vcRcSqA) </br>
   
 ## Installation

--- a/README.md
+++ b/README.md
@@ -57,8 +57,6 @@
 - **ESP8266** (all variants) - WiFi with SSL/TLS support
 - **ESP32** (all variants) - WiFi with SSL/TLS support
 - **Raspberry Pi Pico W (RP2040)** - WiFi with SSL/TLS support
-
-### Supported (No Camera Features)
 - **Arduino Nano 33 IoT** - WiFiNINA library, SSL/TLS enabled
 - **Arduino MKR WiFi 1010** - WiFiNINA library, SSL/TLS enabled
 - **Arduino UNO R4 WiFi** - WiFiS3 library, **no SSL/TLS support**

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Version 5.0.0
+
+### Added
+- **Arduino UNO R4 WiFi support** (WiFiS3, non-SSL)
+- **Arduino Nano 33 IoT support** (WiFiNINA, SSL enabled)
+- **Arduino MKR WiFi 1010 support** (WiFiNINA, SSL enabled) 
+---
+
 ## Version 4.1.0
   New: 
   1. The `sendSettingEvent` method has been added to SettingController.

--- a/examples/ACUnit/ACUnit.ino
+++ b/examples/ACUnit/ACUnit.ino
@@ -49,44 +49,44 @@ bool globalPowerState;
 int globalFanSpeed;
 
 bool onPowerState(const String &deviceId, bool &state) {
-  Serial.printf("Thermostat %s turned %s\r\n", deviceId.c_str(), state?"on":"off");
+  SINRICPRO_PRINTF("Thermostat %s turned %s\r\n", deviceId.c_str(), state?"on":"off");
   globalPowerState = state; 
   return true; // request handled properly
 }
 
 bool onTargetTemperature(const String &deviceId, float &temperature) {
-  Serial.printf("Thermostat %s set temperature to %f\r\n", deviceId.c_str(), temperature);
+  SINRICPRO_PRINTF("Thermostat %s set temperature to %f\r\n", deviceId.c_str(), temperature);
   globalTemperature = temperature;
   return true;
 }
 
 bool onAdjustTargetTemperature(const String & deviceId, float &temperatureDelta) {
   globalTemperature += temperatureDelta;  // calculate absolut temperature
-  Serial.printf("Thermostat %s changed temperature about %f to %f", deviceId.c_str(), temperatureDelta, globalTemperature);
+  SINRICPRO_PRINTF("Thermostat %s changed temperature about %f to %f", deviceId.c_str(), temperatureDelta, globalTemperature);
   temperatureDelta = globalTemperature; // return absolut temperature
   return true;
 }
 
 bool onThermostatMode(const String &deviceId, String &mode) {
-  Serial.printf("Thermostat %s set to mode %s\r\n", deviceId.c_str(), mode.c_str());
+  SINRICPRO_PRINTF("Thermostat %s set to mode %s\r\n", deviceId.c_str(), mode.c_str());
   return true;
 }
 
 bool onRangeValue(const String &deviceId, int &rangeValue) {
-  Serial.printf("Fan speed set to %d\r\n", rangeValue);
+  SINRICPRO_PRINTF("Fan speed set to %d\r\n", rangeValue);
   globalFanSpeed = rangeValue;
   return true;
 }
 
 bool onAdjustRangeValue(const String &deviceId, int &valueDelta) {
   globalFanSpeed += valueDelta;
-  Serial.printf("Fan speed changed about %d to %d\r\n", valueDelta, globalFanSpeed);
+  SINRICPRO_PRINTF("Fan speed changed about %d to %d\r\n", valueDelta, globalFanSpeed);
   valueDelta = globalFanSpeed;
   return true;
 }
 
 void setupWiFi() {
-  Serial.printf("\r\n[Wifi]: Connecting");
+  SINRICPRO_PRINTF("\r\n[Wifi]: Connecting");
 
   #if defined(ESP8266)
     WiFi.setSleepMode(WIFI_NONE_SLEEP); 
@@ -99,11 +99,11 @@ void setupWiFi() {
   WiFi.begin(WIFI_SSID, WIFI_PASS);  
 
   while (WiFi.status() != WL_CONNECTED) {
-    Serial.printf(".");
+    SINRICPRO_PRINTF(".");
     delay(250);
   }
   IPAddress localIP = WiFi.localIP();
-  Serial.printf("connected!\r\n[WiFi]: IP-Address is %d.%d.%d.%d\r\n", localIP[0], localIP[1], localIP[2], localIP[3]);
+  SINRICPRO_PRINTF("connected!\r\n[WiFi]: IP-Address is %d.%d.%d.%d\r\n", localIP[0], localIP[1], localIP[2], localIP[3]);
 }
 
 void setupSinricPro() {
@@ -116,13 +116,13 @@ void setupSinricPro() {
   myAcUnit.onAdjustRangeValue(onAdjustRangeValue);
 
   // setup SinricPro
-  SinricPro.onConnected([](){ Serial.printf("Connected to SinricPro\r\n"); }); 
-  SinricPro.onDisconnected([](){ Serial.printf("Disconnected from SinricPro\r\n"); });
+  SinricPro.onConnected([](){ SINRICPRO_PRINTF("Connected to SinricPro\r\n"); }); 
+  SinricPro.onDisconnected([](){ SINRICPRO_PRINTF("Disconnected from SinricPro\r\n"); });
   SinricPro.begin(APP_KEY, APP_SECRET);
 }
 
 void setup() {
-  Serial.begin(BAUD_RATE); Serial.printf("\r\n\r\n");
+  Serial.begin(BAUD_RATE); SINRICPRO_PRINTF("\r\n\r\n");
   setupWiFi();
   setupSinricPro();
 }

--- a/examples/ACUnit/ACUnit.ino
+++ b/examples/ACUnit/ACUnit.ino
@@ -25,6 +25,13 @@
   #include <ESP8266WiFi.h>
 #elif defined(ESP32) || defined(ARDUINO_ARCH_RP2040)
   #include <WiFi.h>
+#elif defined(ARDUINO_SAMD_MKRWIFI1010) || defined(ARDUINO_SAMD_NANO_33_IOT)
+  #include <WiFiNINA.h>
+#elif defined(ARDUINO_UNOWIFIR4) || defined(ARDUINO_MINIMA)
+  #include <WiFiS3.h>
+  #ifndef SINRICPRO_NOSSL
+    #define SINRICPRO_NOSSL
+  #endif
 #endif
 
 #include "SinricPro.h"

--- a/examples/AirQualitySensor/AirQualitySensor/AirQualitySensor.ino
+++ b/examples/AirQualitySensor/AirQualitySensor/AirQualitySensor.ino
@@ -26,6 +26,13 @@
   #include <ESP8266WiFi.h>
 #elif defined(ESP32) || defined(ARDUINO_ARCH_RP2040)
   #include <WiFi.h>
+#elif defined(ARDUINO_SAMD_MKRWIFI1010) || defined(ARDUINO_SAMD_NANO_33_IOT)
+  #include <WiFiNINA.h>
+#elif defined(ARDUINO_UNOWIFIR4) || defined(ARDUINO_MINIMA)
+  #include <WiFiS3.h>
+  #ifndef SINRICPRO_NOSSL
+    #define SINRICPRO_NOSSL
+  #endif
 #endif
 
 #include "SinricPro.h"

--- a/examples/AirQualitySensor/AirQualitySensor/AirQualitySensor.ino
+++ b/examples/AirQualitySensor/AirQualitySensor/AirQualitySensor.ino
@@ -51,7 +51,7 @@ unsigned long dispatchTime = millis() + MIN;
  
  // setup function for WiFi connection
 void setupWiFi() {
-  Serial.printf("\r\n[Wifi]: Connecting");
+  SINRICPRO_PRINTF("\r\n[Wifi]: Connecting");
 
   #if defined(ESP8266)
     WiFi.setSleepMode(WIFI_NONE_SLEEP); 
@@ -64,10 +64,10 @@ void setupWiFi() {
   WiFi.begin(WIFI_SSID, WIFI_PASS);
 
   while (WiFi.status() != WL_CONNECTED) {
-    Serial.printf(".");
+    SINRICPRO_PRINTF(".");
     delay(250);
   }
-  Serial.printf("connected!\r\n[WiFi]: IP-Address is %s\r\n", WiFi.localIP().toString().c_str());
+  SINRICPRO_PRINTF("connected!\r\n[WiFi]: IP-Address is %s\r\n", WiFi.localIP().toString().c_str());
 }
 
 // setup function for SinricPro
@@ -78,13 +78,13 @@ void setupSinricPro() {
   // set callback function to device
  
   // setup SinricPro
-  SinricPro.onConnected([](){ Serial.printf("Connected to SinricPro\r\n"); }); 
-  SinricPro.onDisconnected([](){ Serial.printf("Disconnected from SinricPro\r\n"); });
+  SinricPro.onConnected([](){ SINRICPRO_PRINTF("Connected to SinricPro\r\n"); }); 
+  SinricPro.onDisconnected([](){ SINRICPRO_PRINTF("Disconnected from SinricPro\r\n"); });
   SinricPro.begin(APP_KEY, APP_SECRET);
 } 
 
 void setup() {
-  Serial.begin(BAUD_RATE); Serial.printf("\r\n\r\n");
+  Serial.begin(BAUD_RATE); SINRICPRO_PRINTF("\r\n\r\n");
   setupWiFi();
   setupSinricPro();  
 }
@@ -103,7 +103,7 @@ void loop() {
     if(success) {
       Serial.println("Air Quality event sent! ..");
     } else {
-      Serial.printf("Something went wrong...could not send Event to server!\r\n");
+      SINRICPRO_PRINTF("Something went wrong...could not send Event to server!\r\n");
     }
 
     dispatchTime += MIN;

--- a/examples/AirQualitySensor/AirQualitySensor_gp2y1014au0f/AirQualitySensor_gp2y1014au0f.ino
+++ b/examples/AirQualitySensor/AirQualitySensor_gp2y1014au0f/AirQualitySensor_gp2y1014au0f.ino
@@ -59,7 +59,7 @@ GP2YDustSensor dustSensor(GP2YDustSensorType::GP2Y1014AU0F, SHARP_LED_PIN, SHARP
  
  // setup function for WiFi connection
 void setupWiFi() {
-  Serial.printf("\r\n[Wifi]: Connecting");
+  SINRICPRO_PRINTF("\r\n[Wifi]: Connecting");
 
   #if defined(ESP8266)
     WiFi.setSleepMode(WIFI_NONE_SLEEP); 
@@ -72,10 +72,10 @@ void setupWiFi() {
   WiFi.begin(WIFI_SSID, WIFI_PASS);
 
   while (WiFi.status() != WL_CONNECTED) {
-    Serial.printf(".");
+    SINRICPRO_PRINTF(".");
     delay(250);
   }
-  Serial.printf("connected!\r\n[WiFi]: IP-Address is %s\r\n", WiFi.localIP().toString().c_str());
+  SINRICPRO_PRINTF("connected!\r\n[WiFi]: IP-Address is %s\r\n", WiFi.localIP().toString().c_str());
 }
 
 // setup function for SinricPro
@@ -84,8 +84,8 @@ void setupSinricPro() {
   SinricProAirQualitySensor& mySinricProAirQualitySensor = SinricPro[DEVICE_ID];
 
   // setup SinricPro
-  SinricPro.onConnected([](){ Serial.printf("Connected to SinricPro\r\n"); }); 
-  SinricPro.onDisconnected([](){ Serial.printf("Disconnected from SinricPro\r\n"); });
+  SinricPro.onConnected([](){ SINRICPRO_PRINTF("Connected to SinricPro\r\n"); }); 
+  SinricPro.onDisconnected([](){ SINRICPRO_PRINTF("Disconnected from SinricPro\r\n"); });
   SinricPro.begin(APP_KEY, APP_SECRET);
 }
 
@@ -96,7 +96,7 @@ void setupDustSensor() {
 }
 
 void setup() {
-  Serial.begin(BAUD_RATE); Serial.printf("\r\n\r\n");
+  Serial.begin(BAUD_RATE); SINRICPRO_PRINTF("\r\n\r\n");
   setupWiFi();
   setupSinricPro();
   setupDustSensor();  
@@ -122,7 +122,7 @@ void loop() {
     if(success) {
       Serial.println("Air Quality event sent! ..");
     } else {
-      Serial.printf("Something went wrong...could not send Event to server!\r\n");
+      SINRICPRO_PRINTF("Something went wrong...could not send Event to server!\r\n");
     }
 
     dispatchTime += MIN;

--- a/examples/AirQualitySensor/AirQualitySensor_gp2y1014au0f/AirQualitySensor_gp2y1014au0f.ino
+++ b/examples/AirQualitySensor/AirQualitySensor_gp2y1014au0f/AirQualitySensor_gp2y1014au0f.ino
@@ -29,6 +29,13 @@
   #include <ESP8266WiFi.h>
 #elif defined(ESP32) || defined(ARDUINO_ARCH_RP2040)
   #include <WiFi.h>
+#elif defined(ARDUINO_SAMD_MKRWIFI1010) || defined(ARDUINO_SAMD_NANO_33_IOT)
+  #include <WiFiNINA.h>
+#elif defined(ARDUINO_UNOWIFIR4) || defined(ARDUINO_MINIMA)
+  #include <WiFiS3.h>
+  #ifndef SINRICPRO_NOSSL
+    #define SINRICPRO_NOSSL
+  #endif
 #endif
 
 #include "SinricPro.h"

--- a/examples/Blinds/Blinds.ino
+++ b/examples/Blinds/Blinds.ino
@@ -48,19 +48,19 @@ int blindsPosition = 0;
 bool powerState = false;
 
 bool onPowerState(const String &deviceId, bool &state) {
-  Serial.printf("Device %s power turned %s \r\n", deviceId.c_str(), state?"on":"off");
+  SINRICPRO_PRINTF("Device %s power turned %s \r\n", deviceId.c_str(), state?"on":"off");
   powerState = state;
   return true; // request handled properly
 }
 
 bool onRangeValue(const String &deviceId, int &position) {
-  Serial.printf("Device %s set position to %d\r\n", deviceId.c_str(), position);
+  SINRICPRO_PRINTF("Device %s set position to %d\r\n", deviceId.c_str(), position);
   return true; // request handled properly
 }
 
 bool onAdjustRangeValue(const String &deviceId, int &positionDelta) {
   blindsPosition += positionDelta;
-  Serial.printf("Device %s position changed about %i to %d\r\n", deviceId.c_str(), positionDelta, blindsPosition);
+  SINRICPRO_PRINTF("Device %s position changed about %i to %d\r\n", deviceId.c_str(), positionDelta, blindsPosition);
   positionDelta = blindsPosition; // calculate and return absolute position
   return true; // request handled properly
 }
@@ -68,7 +68,7 @@ bool onAdjustRangeValue(const String &deviceId, int &positionDelta) {
 
 // setup function for WiFi connection
 void setupWiFi() {
-  Serial.printf("\r\n[Wifi]: Connecting");
+  SINRICPRO_PRINTF("\r\n[Wifi]: Connecting");
 
   #if defined(ESP8266)
     WiFi.setSleepMode(WIFI_NONE_SLEEP); 
@@ -81,11 +81,11 @@ void setupWiFi() {
   WiFi.begin(WIFI_SSID, WIFI_PASS);
 
   while (WiFi.status() != WL_CONNECTED) {
-    Serial.printf(".");
+    SINRICPRO_PRINTF(".");
     delay(250);
   }
   IPAddress localIP = WiFi.localIP();
-  Serial.printf("connected!\r\n[WiFi]: IP-Address is %d.%d.%d.%d\r\n", localIP[0], localIP[1], localIP[2], localIP[3]);
+  SINRICPRO_PRINTF("connected!\r\n[WiFi]: IP-Address is %d.%d.%d.%d\r\n", localIP[0], localIP[1], localIP[2], localIP[3]);
 }
 
 void setupSinricPro() {
@@ -96,14 +96,14 @@ void setupSinricPro() {
   myBlinds.onAdjustRangeValue(onAdjustRangeValue);
 
   // setup SinricPro
-  SinricPro.onConnected([](){ Serial.printf("Connected to SinricPro\r\n"); }); 
-  SinricPro.onDisconnected([](){ Serial.printf("Disconnected from SinricPro\r\n"); });
+  SinricPro.onConnected([](){ SINRICPRO_PRINTF("Connected to SinricPro\r\n"); }); 
+  SinricPro.onDisconnected([](){ SINRICPRO_PRINTF("Disconnected from SinricPro\r\n"); });
   SinricPro.begin(APP_KEY, APP_SECRET);
 }
 
 // main setup function
 void setup() {
-  Serial.begin(BAUD_RATE); Serial.printf("\r\n\r\n");
+  Serial.begin(BAUD_RATE); SINRICPRO_PRINTF("\r\n\r\n");
   setupWiFi();
   setupSinricPro();
 }

--- a/examples/Blinds/Blinds.ino
+++ b/examples/Blinds/Blinds.ino
@@ -25,6 +25,13 @@
   #include <ESP8266WiFi.h>
 #elif defined(ESP32) || defined(ARDUINO_ARCH_RP2040)
   #include <WiFi.h>
+#elif defined(ARDUINO_SAMD_MKRWIFI1010) || defined(ARDUINO_SAMD_NANO_33_IOT)
+  #include <WiFiNINA.h>
+#elif defined(ARDUINO_UNOWIFIR4) || defined(ARDUINO_MINIMA)
+  #include <WiFiS3.h>
+  #ifndef SINRICPRO_NOSSL
+    #define SINRICPRO_NOSSL
+  #endif
 #endif
 
 #include "SinricPro.h"

--- a/examples/ContactSensor/ContactSensor.ino
+++ b/examples/ContactSensor/ContactSensor.ino
@@ -28,6 +28,13 @@
   #include <ESP8266WiFi.h>
 #elif defined(ESP32) || defined(ARDUINO_ARCH_RP2040)
   #include <WiFi.h>
+#elif defined(ARDUINO_SAMD_MKRWIFI1010) || defined(ARDUINO_SAMD_NANO_33_IOT)
+  #include <WiFiNINA.h>
+#elif defined(ARDUINO_UNOWIFIR4) || defined(ARDUINO_MINIMA)
+  #include <WiFiS3.h>
+  #ifndef SINRICPRO_NOSSL
+    #define SINRICPRO_NOSSL
+  #endif
 #endif
 
 #include "SinricPro.h"

--- a/examples/ContactSensor/ContactSensor.ino
+++ b/examples/ContactSensor/ContactSensor.ino
@@ -69,20 +69,20 @@ void handleContactsensor() {
   bool actualContactState = digitalRead(CONTACT_PIN);   // read actual state of contactsensor
 
   if (actualContactState != lastContactState) {         // if state has changed
-    Serial.printf("Contactsensor is %s now\r\n", actualContactState?"open":"closed");
+    SINRICPRO_PRINTF("Contactsensor is %s now\r\n", actualContactState?"open":"closed");
     lastContactState = actualContactState;              // update last known state
     lastChange = actualMillis;                          // update debounce time
     SinricProContactsensor &myContact = SinricPro[CONTACT_ID]; // get contact sensor device
     bool success = myContact.sendContactEvent(actualContactState);      // send event with actual state
     if(!success) {
-      Serial.printf("Something went wrong...could not send Event to server!\r\n");
+      SINRICPRO_PRINTF("Something went wrong...could not send Event to server!\r\n");
     }
   }
 }
 
 // setup function for WiFi connection
 void setupWiFi() {
-  Serial.printf("\r\n[Wifi]: Connecting");
+  SINRICPRO_PRINTF("\r\n[Wifi]: Connecting");
 
   #if defined(ESP8266)
     WiFi.setSleepMode(WIFI_NONE_SLEEP); 
@@ -95,11 +95,11 @@ void setupWiFi() {
   WiFi.begin(WIFI_SSID, WIFI_PASS);
 
   while (WiFi.status() != WL_CONNECTED) {
-    Serial.printf(".");
+    SINRICPRO_PRINTF(".");
     delay(250);
   }
   IPAddress localIP = WiFi.localIP();
-  Serial.printf("connected!\r\n[WiFi]: IP-Address is %d.%d.%d.%d\r\n", localIP[0], localIP[1], localIP[2], localIP[3]);
+  SINRICPRO_PRINTF("connected!\r\n[WiFi]: IP-Address is %d.%d.%d.%d\r\n", localIP[0], localIP[1], localIP[2], localIP[3]);
 }
 
 // setup function for SinricPro
@@ -108,14 +108,14 @@ void setupSinricPro() {
   SinricProContactsensor& myContact = SinricPro[CONTACT_ID];
 
   // setup SinricPro
-  SinricPro.onConnected([](){ Serial.printf("Connected to SinricPro\r\n"); });
-  SinricPro.onDisconnected([](){ Serial.printf("Disconnected from SinricPro\r\n"); });
+  SinricPro.onConnected([](){ SINRICPRO_PRINTF("Connected to SinricPro\r\n"); });
+  SinricPro.onDisconnected([](){ SINRICPRO_PRINTF("Disconnected from SinricPro\r\n"); });
   SinricPro.begin(APP_KEY, APP_SECRET);
 }
 
 // main setup function
 void setup() {
-  Serial.begin(BAUD_RATE); Serial.printf("\r\n\r\n");
+  Serial.begin(BAUD_RATE); SINRICPRO_PRINTF("\r\n\r\n");
 
   pinMode(CONTACT_PIN, INPUT);
 

--- a/examples/DimSwitch/DimSwitch.ino
+++ b/examples/DimSwitch/DimSwitch.ino
@@ -49,26 +49,26 @@ struct {
 } device_state;
 
 bool onPowerState(const String &deviceId, bool &state) {
-  Serial.printf("Device %s power turned %s \r\n", deviceId.c_str(), state?"on":"off");
+  SINRICPRO_PRINTF("Device %s power turned %s \r\n", deviceId.c_str(), state?"on":"off");
   device_state.powerState = state;
   return true; // request handled properly
 }
 
 bool onPowerLevel(const String &deviceId, int &powerLevel) {
   device_state.powerLevel = powerLevel;
-  Serial.printf("Device %s power level changed to %d\r\n", deviceId.c_str(), device_state.powerLevel);
+  SINRICPRO_PRINTF("Device %s power level changed to %d\r\n", deviceId.c_str(), device_state.powerLevel);
   return true;
 }
 
 bool onAdjustPowerLevel(const String &deviceId, int &levelDelta) {
   device_state.powerLevel += levelDelta;
-  Serial.printf("Device %s power level changed about %i to %d\r\n", deviceId.c_str(), levelDelta, device_state.powerLevel);
+  SINRICPRO_PRINTF("Device %s power level changed about %i to %d\r\n", deviceId.c_str(), levelDelta, device_state.powerLevel);
   levelDelta = device_state.powerLevel;
   return true;
 }
 
 void setupWiFi() {
-  Serial.printf("\r\n[Wifi]: Connecting");
+  SINRICPRO_PRINTF("\r\n[Wifi]: Connecting");
 
   #if defined(ESP8266)
     WiFi.setSleepMode(WIFI_NONE_SLEEP); 
@@ -81,11 +81,11 @@ void setupWiFi() {
   WiFi.begin(WIFI_SSID, WIFI_PASS);
 
   while (WiFi.status() != WL_CONNECTED) {
-    Serial.printf(".");
+    SINRICPRO_PRINTF(".");
     delay(250);
   }
   IPAddress localIP = WiFi.localIP();
-  Serial.printf("connected!\r\n[WiFi]: IP-Address is %d.%d.%d.%d\r\n", localIP[0], localIP[1], localIP[2], localIP[3]);
+  SINRICPRO_PRINTF("connected!\r\n[WiFi]: IP-Address is %d.%d.%d.%d\r\n", localIP[0], localIP[1], localIP[2], localIP[3]);
 }
 
 void setupSinricPro() {
@@ -97,14 +97,14 @@ void setupSinricPro() {
   myDimSwitch.onAdjustPowerLevel(onAdjustPowerLevel);
 
   // setup SinricPro
-  SinricPro.onConnected([](){ Serial.printf("Connected to SinricPro\r\n"); }); 
-  SinricPro.onDisconnected([](){ Serial.printf("Disconnected from SinricPro\r\n"); });
+  SinricPro.onConnected([](){ SINRICPRO_PRINTF("Connected to SinricPro\r\n"); }); 
+  SinricPro.onDisconnected([](){ SINRICPRO_PRINTF("Disconnected from SinricPro\r\n"); });
   SinricPro.begin(APP_KEY, APP_SECRET);
 }
 
 // main setup function
 void setup() {
-  Serial.begin(BAUD_RATE); Serial.printf("\r\n\r\n");
+  Serial.begin(BAUD_RATE); SINRICPRO_PRINTF("\r\n\r\n");
   setupWiFi();
   setupSinricPro();
 }

--- a/examples/DimSwitch/DimSwitch.ino
+++ b/examples/DimSwitch/DimSwitch.ino
@@ -23,6 +23,13 @@
   #include <ESP8266WiFi.h>
 #elif defined(ESP32) || defined(ARDUINO_ARCH_RP2040)
   #include <WiFi.h>
+#elif defined(ARDUINO_SAMD_MKRWIFI1010) || defined(ARDUINO_SAMD_NANO_33_IOT)
+  #include <WiFiNINA.h>
+#elif defined(ARDUINO_UNOWIFIR4) || defined(ARDUINO_MINIMA)
+  #include <WiFiS3.h>
+  #ifndef SINRICPRO_NOSSL
+    #define SINRICPRO_NOSSL
+  #endif
 #endif
 
 #include "SinricPro.h"

--- a/examples/Fan/Fan.ino
+++ b/examples/Fan/Fan.ino
@@ -23,6 +23,13 @@
   #include <ESP8266WiFi.h>
 #elif defined(ESP32) || defined(ARDUINO_ARCH_RP2040)
   #include <WiFi.h>
+#elif defined(ARDUINO_SAMD_MKRWIFI1010) || defined(ARDUINO_SAMD_NANO_33_IOT)
+  #include <WiFiNINA.h>
+#elif defined(ARDUINO_UNOWIFIR4) || defined(ARDUINO_MINIMA)
+  #include <WiFiS3.h>
+  #ifndef SINRICPRO_NOSSL
+    #define SINRICPRO_NOSSL
+  #endif
 #endif
 
 #include "SinricPro.h"

--- a/examples/Fan/Fan.ino
+++ b/examples/Fan/Fan.ino
@@ -50,7 +50,7 @@ struct {
 } device_state;
 
 bool onPowerState(const String &deviceId, bool &state) {
-  Serial.printf("Fan turned %s\r\n", state?"on":"off");
+  SINRICPRO_PRINTF("Fan turned %s\r\n", state?"on":"off");
   device_state.powerState = state;
   return true; // request handled properly
 }
@@ -58,21 +58,21 @@ bool onPowerState(const String &deviceId, bool &state) {
 // Fan rangeValue is from 1..3
 bool onRangeValue(const String &deviceId, int& rangeValue) {
   device_state.fanSpeed = rangeValue;
-  Serial.printf("Fan speed changed to %d\r\n", device_state.fanSpeed);
+  SINRICPRO_PRINTF("Fan speed changed to %d\r\n", device_state.fanSpeed);
   return true;
 }
 
 // Fan rangeValueDelta is from -3..+3
 bool onAdjustRangeValue(const String &deviceId, int& rangeValueDelta) {
   device_state.fanSpeed += rangeValueDelta;
-  Serial.printf("Fan speed changed about %i to %d\r\n", rangeValueDelta, device_state.fanSpeed);
+  SINRICPRO_PRINTF("Fan speed changed about %i to %d\r\n", rangeValueDelta, device_state.fanSpeed);
 
   rangeValueDelta = device_state.fanSpeed; // return absolute fan speed
   return true;
 }
 
 void setupWiFi() {
-  Serial.printf("\r\n[Wifi]: Connecting");
+  SINRICPRO_PRINTF("\r\n[Wifi]: Connecting");
   
   #if defined(ESP8266)
     WiFi.setSleepMode(WIFI_NONE_SLEEP); 
@@ -85,10 +85,10 @@ void setupWiFi() {
   WiFi.begin(WIFI_SSID, WIFI_PASS);
 
   while (WiFi.status() != WL_CONNECTED) {
-    Serial.printf(".");
+    SINRICPRO_PRINTF(".");
     delay(250);
   }
-  Serial.printf("connected!\r\n[WiFi]: IP-Address is %s\r\n", WiFi.localIP().toString().c_str());
+  SINRICPRO_PRINTF("connected!\r\n[WiFi]: IP-Address is %s\r\n", WiFi.localIP().toString().c_str());
 }
 
 void setupSinricPro() {
@@ -100,14 +100,14 @@ void setupSinricPro() {
   myFan.onAdjustRangeValue(onAdjustRangeValue);
 
   // setup SinricPro
-  SinricPro.onConnected([](){ Serial.printf("Connected to SinricPro\r\n"); }); 
-  SinricPro.onDisconnected([](){ Serial.printf("Disconnected from SinricPro\r\n"); });
+  SinricPro.onConnected([](){ SINRICPRO_PRINTF("Connected to SinricPro\r\n"); }); 
+  SinricPro.onDisconnected([](){ SINRICPRO_PRINTF("Disconnected from SinricPro\r\n"); });
   SinricPro.begin(APP_KEY, APP_SECRET);
 }
 
 // main setup function
 void setup() {
-  Serial.begin(BAUD_RATE); Serial.printf("\r\n\r\n");
+  Serial.begin(BAUD_RATE); SINRICPRO_PRINTF("\r\n\r\n");
   setupWiFi();
   setupSinricPro();
 }

--- a/examples/GarageDoor/GarageDoor.ino
+++ b/examples/GarageDoor/GarageDoor.ino
@@ -46,12 +46,12 @@
 
 
 bool onDoorState(const String& deviceId, bool &doorState) {
-  Serial.printf("Garagedoor is %s now.\r\n", doorState?"closed":"open");
+  SINRICPRO_PRINTF("Garagedoor is %s now.\r\n", doorState?"closed":"open");
   return true;
 }
 
 void setupWiFi() {
-  Serial.printf("\r\n[Wifi]: Connecting");
+  SINRICPRO_PRINTF("\r\n[Wifi]: Connecting");
 
   #if defined(ESP8266)
     WiFi.setSleepMode(WIFI_NONE_SLEEP); 
@@ -64,11 +64,11 @@ void setupWiFi() {
   WiFi.begin(WIFI_SSID, WIFI_PASS); 
 
   while (WiFi.status() != WL_CONNECTED) {
-    Serial.printf(".");
+    SINRICPRO_PRINTF(".");
     delay(250);
   }
   IPAddress localIP = WiFi.localIP();
-  Serial.printf("connected!\r\n[WiFi]: IP-Address is %d.%d.%d.%d\r\n", localIP[0], localIP[1], localIP[2], localIP[3]);
+  SINRICPRO_PRINTF("connected!\r\n[WiFi]: IP-Address is %d.%d.%d.%d\r\n", localIP[0], localIP[1], localIP[2], localIP[3]);
 }
 
 void setupSinricPro() {
@@ -76,13 +76,13 @@ void setupSinricPro() {
   myGarageDoor.onDoorState(onDoorState);
 
   // setup SinricPro
-  SinricPro.onConnected([](){ Serial.printf("Connected to SinricPro\r\n"); }); 
-  SinricPro.onDisconnected([](){ Serial.printf("Disconnected from SinricPro\r\n"); });
+  SinricPro.onConnected([](){ SINRICPRO_PRINTF("Connected to SinricPro\r\n"); }); 
+  SinricPro.onDisconnected([](){ SINRICPRO_PRINTF("Disconnected from SinricPro\r\n"); });
   SinricPro.begin(APP_KEY, APP_SECRET);
 }
 
 void setup() {
-  Serial.begin(BAUD_RATE); Serial.printf("\r\n\r\n");
+  Serial.begin(BAUD_RATE); SINRICPRO_PRINTF("\r\n\r\n");
   setupWiFi();
   setupSinricPro();
 }

--- a/examples/GarageDoor/GarageDoor.ino
+++ b/examples/GarageDoor/GarageDoor.ino
@@ -25,6 +25,13 @@
   #include <ESP8266WiFi.h>
 #elif defined(ESP32) || defined(ARDUINO_ARCH_RP2040)
   #include <WiFi.h>
+#elif defined(ARDUINO_SAMD_MKRWIFI1010) || defined(ARDUINO_SAMD_NANO_33_IOT)
+  #include <WiFiNINA.h>
+#elif defined(ARDUINO_UNOWIFIR4) || defined(ARDUINO_MINIMA)
+  #include <WiFiS3.h>
+  #ifndef SINRICPRO_NOSSL
+    #define SINRICPRO_NOSSL
+  #endif
 #endif
 
 #include "SinricPro.h"

--- a/examples/Health/Health.ino
+++ b/examples/Health/Health.ino
@@ -54,7 +54,7 @@ HealthDiagnostics healthDiagnostics;
  
 // setup function for WiFi connection
 void setupWiFi() {
-  Serial.printf("\r\n[Wifi]: Connecting");
+  SINRICPRO_PRINTF("\r\n[Wifi]: Connecting");
 
 #if defined(ESP8266)
   WiFi.setSleepMode(WIFI_NONE_SLEEP);
@@ -67,11 +67,11 @@ void setupWiFi() {
   WiFi.begin(WIFI_SSID, WIFI_PASS);
 
   while (WiFi.status() != WL_CONNECTED) {
-    Serial.printf(".");
+    SINRICPRO_PRINTF(".");
     delay(250);
   }
 
-  Serial.printf("connected!\r\n[WiFi]: IP-Address is %s\r\n", WiFi.localIP().toString().c_str());
+  SINRICPRO_PRINTF("connected!\r\n[WiFi]: IP-Address is %s\r\n", WiFi.localIP().toString().c_str());
 }
 
 // setup function for SinricPro
@@ -80,11 +80,11 @@ void setupSinricPro() {
 
   // setup SinricPro
   SinricPro.onConnected([]() {
-    Serial.printf("Connected to SinricPro\r\n");
+    SINRICPRO_PRINTF("Connected to SinricPro\r\n");
   });
   
   SinricPro.onDisconnected([]() {
-    Serial.printf("Disconnected from SinricPro\r\n");
+    SINRICPRO_PRINTF("Disconnected from SinricPro\r\n");
   });
   
   SinricPro.onReportHealth([&](String &healthReport) {
@@ -97,7 +97,7 @@ void setupSinricPro() {
 // main setup function
 void setup() {
   Serial.begin(BAUD_RATE);
-  Serial.printf("\r\n\r\n");
+  SINRICPRO_PRINTF("\r\n\r\n");
   setupWiFi();
   setupSinricPro();
 }

--- a/examples/Health/Health.ino
+++ b/examples/Health/Health.ino
@@ -25,8 +25,17 @@
 
 #if defined(ESP8266)
   #include <ESP8266WiFi.h>
-#elif defined(ESP32) 
+#elif defined(ESP32)
   #include <WiFi.h>
+#elif defined(ARDUINO_ARCH_RP2040)
+  #include <WiFi.h>
+#elif defined(ARDUINO_SAMD_MKRWIFI1010) || defined(ARDUINO_SAMD_NANO_33_IOT)
+  #include <WiFiNINA.h>
+#elif defined(ARDUINO_UNOWIFIR4) || defined(ARDUINO_MINIMA)
+  #include <WiFiS3.h>
+  #ifndef SINRICPRO_NOSSL
+    #define SINRICPRO_NOSSL
+  #endif
 #endif
 
 #include "SinricPro.h"

--- a/examples/Light/Light/Light.ino
+++ b/examples/Light/Light/Light.ino
@@ -23,6 +23,13 @@
   #include <ESP8266WiFi.h>
 #elif defined(ESP32) || defined(ARDUINO_ARCH_RP2040)
   #include <WiFi.h>
+#elif defined(ARDUINO_SAMD_MKRWIFI1010) || defined(ARDUINO_SAMD_NANO_33_IOT)
+  #include <WiFiNINA.h>
+#elif defined(ARDUINO_UNOWIFIR4) || defined(ARDUINO_MINIMA)
+  #include <WiFiS3.h>
+  #ifndef SINRICPRO_NOSSL
+    #define SINRICPRO_NOSSL
+  #endif
 #endif
 
 #include "SinricPro.h"

--- a/examples/Light/Light/Light.ino
+++ b/examples/Light/Light/Light.ino
@@ -53,10 +53,10 @@ std::map<int, int> colorTemperatureIndex;
 // so that the map can be used to do a reverse search like
 // int index = colorTemperateIndex[4000]; <- will result in index == 2
 void setupColorTemperatureIndex() {
-  Serial.printf("Setup color temperature lookup table\r\n");
+  SINRICPRO_PRINTF("Setup color temperature lookup table\r\n");
   for (int i=0;i < max_color_temperatures; i++) {
     colorTemperatureIndex[colorTemperatureArray[i]] = i;
-    Serial.printf("colorTemperatureIndex[%i] = %i\r\n", colorTemperatureArray[i], colorTemperatureIndex[colorTemperatureArray[i]]);
+    SINRICPRO_PRINTF("colorTemperatureIndex[%i] = %i\r\n", colorTemperatureArray[i], colorTemperatureIndex[colorTemperatureArray[i]]);
   }
 }
 
@@ -73,20 +73,20 @@ struct {
 } device_state; 
 
 bool onPowerState(const String &deviceId, bool &state) {
-  Serial.printf("Device %s power turned %s \r\n", deviceId.c_str(), state?"on":"off");
+  SINRICPRO_PRINTF("Device %s power turned %s \r\n", deviceId.c_str(), state?"on":"off");
   device_state.powerState = state;
   return true; // request handled properly
 }
 
 bool onBrightness(const String &deviceId, int &brightness) {
   device_state.brightness = brightness;
-  Serial.printf("Device %s brightness level changed to %d\r\n", deviceId.c_str(), brightness);
+  SINRICPRO_PRINTF("Device %s brightness level changed to %d\r\n", deviceId.c_str(), brightness);
   return true;
 }
 
 bool onAdjustBrightness(const String &deviceId, int brightnessDelta) {
   device_state.brightness += brightnessDelta;
-  Serial.printf("Device %s brightness level changed about %i to %d\r\n", deviceId.c_str(), brightnessDelta, device_state.brightness);
+  SINRICPRO_PRINTF("Device %s brightness level changed about %i to %d\r\n", deviceId.c_str(), brightnessDelta, device_state.brightness);
   brightnessDelta = device_state.brightness;
   return true;
 }
@@ -95,13 +95,13 @@ bool onColor(const String &deviceId, byte &r, byte &g, byte &b) {
   device_state.color.r = r;
   device_state.color.g = g;
   device_state.color.b = b;
-  Serial.printf("Device %s color changed to %d, %d, %d (RGB)\r\n", deviceId.c_str(), device_state.color.r, device_state.color.g, device_state.color.b);
+  SINRICPRO_PRINTF("Device %s color changed to %d, %d, %d (RGB)\r\n", deviceId.c_str(), device_state.color.r, device_state.color.g, device_state.color.b);
   return true;
 }
 
 bool onColorTemperature(const String &deviceId, int &colorTemperature) {
   device_state.colorTemperature = colorTemperature;
-  Serial.printf("Device %s color temperature changed to %d\r\n", deviceId.c_str(), device_state.colorTemperature);
+  SINRICPRO_PRINTF("Device %s color temperature changed to %d\r\n", deviceId.c_str(), device_state.colorTemperature);
   return true;
 }
 
@@ -111,7 +111,7 @@ bool onIncreaseColorTemperature(const String &deviceId, int &colorTemperature) {
   if (index < 0) index = 0;                                               // make sure that index stays within array boundaries
   if (index > max_color_temperatures-1) index = max_color_temperatures-1; // make sure that index stays within array boundaries
   device_state.colorTemperature = colorTemperatureArray[index];                  // get the color temperature value
-  Serial.printf("Device %s increased color temperature to %d\r\n", deviceId.c_str(), device_state.colorTemperature);
+  SINRICPRO_PRINTF("Device %s increased color temperature to %d\r\n", deviceId.c_str(), device_state.colorTemperature);
   colorTemperature = device_state.colorTemperature;                              // return current color temperature value
   return true;
 }
@@ -122,13 +122,13 @@ bool onDecreaseColorTemperature(const String &deviceId, int &colorTemperature) {
   if (index < 0) index = 0;                                               // make sure that index stays within array boundaries
   if (index > max_color_temperatures-1) index = max_color_temperatures-1; // make sure that index stays within array boundaries
   device_state.colorTemperature = colorTemperatureArray[index];                  // get the color temperature value
-  Serial.printf("Device %s decreased color temperature to %d\r\n", deviceId.c_str(), device_state.colorTemperature);
+  SINRICPRO_PRINTF("Device %s decreased color temperature to %d\r\n", deviceId.c_str(), device_state.colorTemperature);
   colorTemperature = device_state.colorTemperature;                              // return current color temperature value
   return true;
 }
 
 void setupWiFi() {
-  Serial.printf("\r\n[Wifi]: Connecting");
+  SINRICPRO_PRINTF("\r\n[Wifi]: Connecting");
 
   #if defined(ESP8266)
     WiFi.setSleepMode(WIFI_NONE_SLEEP); 
@@ -141,11 +141,11 @@ void setupWiFi() {
   WiFi.begin(WIFI_SSID, WIFI_PASS); 
 
   while (WiFi.status() != WL_CONNECTED) {
-    Serial.printf(".");
+    SINRICPRO_PRINTF(".");
     delay(250);
   }
   IPAddress localIP = WiFi.localIP();
-  Serial.printf("connected!\r\n[WiFi]: IP-Address is %d.%d.%d.%d\r\n", localIP[0], localIP[1], localIP[2], localIP[3]);
+  SINRICPRO_PRINTF("connected!\r\n[WiFi]: IP-Address is %d.%d.%d.%d\r\n", localIP[0], localIP[1], localIP[2], localIP[3]);
 }
 
 void setupSinricPro() {
@@ -162,14 +162,14 @@ void setupSinricPro() {
   myLight.onDecreaseColorTemperature(onDecreaseColorTemperature);
 
   // setup SinricPro
-  SinricPro.onConnected([](){ Serial.printf("Connected to SinricPro\r\n"); }); 
-  SinricPro.onDisconnected([](){ Serial.printf("Disconnected from SinricPro\r\n"); });
+  SinricPro.onConnected([](){ SINRICPRO_PRINTF("Connected to SinricPro\r\n"); }); 
+  SinricPro.onDisconnected([](){ SINRICPRO_PRINTF("Disconnected from SinricPro\r\n"); });
   SinricPro.begin(APP_KEY, APP_SECRET);
 }
 
 // main setup function
 void setup() {
-  Serial.begin(BAUD_RATE); Serial.printf("\r\n\r\n");
+  Serial.begin(BAUD_RATE); SINRICPRO_PRINTF("\r\n\r\n");
   setupColorTemperatureIndex(); // setup our helper map
   setupWiFi();
   setupSinricPro();

--- a/examples/Light/Light_FastLED_WS2812/Light_FastLED_WS2812.ino
+++ b/examples/Light/Light_FastLED_WS2812/Light_FastLED_WS2812.ino
@@ -93,7 +93,7 @@ void setupFastLED() {
 }
 
 void setupWiFi() {
-  Serial.printf("\r\n[Wifi]: Connecting");
+  SINRICPRO_PRINTF("\r\n[Wifi]: Connecting");
 
   #if defined(ESP8266)
     WiFi.setSleepMode(WIFI_NONE_SLEEP); 
@@ -106,11 +106,11 @@ void setupWiFi() {
   WiFi.begin(WIFI_SSID, WIFI_PASS); 
 
   while (WiFi.status() != WL_CONNECTED) {
-    Serial.printf(".");
+    SINRICPRO_PRINTF(".");
     delay(250);
   }
   IPAddress localIP = WiFi.localIP();
-  Serial.printf("connected!\r\n[WiFi]: IP-Address is %s\r\n", localIP.toString().c_str());
+  SINRICPRO_PRINTF("connected!\r\n[WiFi]: IP-Address is %s\r\n", localIP.toString().c_str());
 }
 
 void setupSinricPro() {
@@ -124,15 +124,15 @@ void setupSinricPro() {
   myLight.onColor(onColor);
 
   // setup SinricPro
-  SinricPro.onConnected([](){ Serial.printf("Connected to SinricPro\r\n"); }); 
-  SinricPro.onDisconnected([](){ Serial.printf("Disconnected from SinricPro\r\n"); });
+  SinricPro.onConnected([](){ SINRICPRO_PRINTF("Connected to SinricPro\r\n"); }); 
+  SinricPro.onDisconnected([](){ SINRICPRO_PRINTF("Disconnected from SinricPro\r\n"); });
   //SinricPro.restoreDeviceStates(true); // Uncomment to restore the last known state from the server.
   SinricPro.begin(APP_KEY, APP_SECRET);
 }
 
 // main setup function
 void setup() {
-  Serial.begin(BAUD_RATE); Serial.printf("\r\n\r\n");
+  Serial.begin(BAUD_RATE); SINRICPRO_PRINTF("\r\n\r\n");
   setupFastLED();
   setupWiFi();
   setupSinricPro();

--- a/examples/Light/Light_FastLED_WS2812/Light_FastLED_WS2812.ino
+++ b/examples/Light/Light_FastLED_WS2812/Light_FastLED_WS2812.ino
@@ -23,6 +23,13 @@
   #include <ESP8266WiFi.h>
 #elif defined(ESP32) || defined(ARDUINO_ARCH_RP2040)
   #include <WiFi.h>
+#elif defined(ARDUINO_SAMD_MKRWIFI1010) || defined(ARDUINO_SAMD_NANO_33_IOT)
+  #include <WiFiNINA.h>
+#elif defined(ARDUINO_UNOWIFIR4) || defined(ARDUINO_MINIMA)
+  #include <WiFiS3.h>
+  #ifndef SINRICPRO_NOSSL
+    #define SINRICPRO_NOSSL
+  #endif
 #endif
 
 #define FASTLED_ESP8266_DMA

--- a/examples/Light/RGB_LED_Stripe_5050/RGB_LED_Stripe_5050.ino
+++ b/examples/Light/RGB_LED_Stripe_5050/RGB_LED_Stripe_5050.ino
@@ -152,7 +152,7 @@ bool onDecreaseColorTemperature(const String& devceId, int& colorTemperature) {
 }
 
 void setupWiFi() {
-    Serial.printf("WiFi: connecting");
+    SINRICPRO_PRINTF("WiFi: connecting");
 
     #if defined(ESP8266)
         WiFi.setSleepMode(WIFI_NONE_SLEEP); 
@@ -165,10 +165,10 @@ void setupWiFi() {
     WiFi.begin(WIFI_SSID, WIFI_PASS); 
     
     while (WiFi.status() != WL_CONNECTED) {
-        Serial.printf(".");
+        SINRICPRO_PRINTF(".");
         delay(250);
     }
-    Serial.printf("connected\r\nIP is %s\r\n", WiFi.localIP().toString().c_str());
+    SINRICPRO_PRINTF("connected\r\nIP is %s\r\n", WiFi.localIP().toString().c_str());
 }
 
 void setupSinricPro() {

--- a/examples/Light/RGB_LED_Stripe_5050/RGB_LED_Stripe_5050.ino
+++ b/examples/Light/RGB_LED_Stripe_5050/RGB_LED_Stripe_5050.ino
@@ -23,6 +23,13 @@
   #include <ESP8266WiFi.h>
 #elif defined(ESP32) || defined(ARDUINO_ARCH_RP2040)
   #include <WiFi.h>
+#elif defined(ARDUINO_SAMD_MKRWIFI1010) || defined(ARDUINO_SAMD_NANO_33_IOT)
+  #include <WiFiNINA.h>
+#elif defined(ARDUINO_UNOWIFIR4) || defined(ARDUINO_MINIMA)
+  #include <WiFiS3.h>
+  #ifndef SINRICPRO_NOSSL
+    #define SINRICPRO_NOSSL
+  #endif
 #endif
 #include <SinricPro.h>
 #include <SinricProLight.h>

--- a/examples/Lock/Lock/Lock.ino
+++ b/examples/Lock/Lock/Lock.ino
@@ -46,12 +46,12 @@
 
 
 bool onLockState(String deviceId, bool &lockState) {
-  Serial.printf("Device %s is %s\r\n", deviceId.c_str(), lockState?"locked":"unlocked");
+  SINRICPRO_PRINTF("Device %s is %s\r\n", deviceId.c_str(), lockState?"locked":"unlocked");
   return true;
 }
 
 void setupWiFi() {
-  Serial.printf("\r\n[Wifi]: Connecting");
+  SINRICPRO_PRINTF("\r\n[Wifi]: Connecting");
 
   #if defined(ESP8266)
     WiFi.setSleepMode(WIFI_NONE_SLEEP); 
@@ -64,11 +64,11 @@ void setupWiFi() {
   WiFi.begin(WIFI_SSID, WIFI_PASS); 
 
   while (WiFi.status() != WL_CONNECTED) {
-    Serial.printf(".");
+    SINRICPRO_PRINTF(".");
     delay(250);
   }
   IPAddress localIP = WiFi.localIP();
-  Serial.printf("connected!\r\n[WiFi]: IP-Address is %d.%d.%d.%d\r\n", localIP[0], localIP[1], localIP[2], localIP[3]);
+  SINRICPRO_PRINTF("connected!\r\n[WiFi]: IP-Address is %d.%d.%d.%d\r\n", localIP[0], localIP[1], localIP[2], localIP[3]);
 }
 
 void setupSinricPro() {
@@ -76,13 +76,13 @@ void setupSinricPro() {
   myLock.onLockState(onLockState);
 
   // setup SinricPro
-  SinricPro.onConnected([](){ Serial.printf("Connected to SinricPro\r\n"); }); 
-  SinricPro.onDisconnected([](){ Serial.printf("Disconnected from SinricPro\r\n"); });
+  SinricPro.onConnected([](){ SINRICPRO_PRINTF("Connected to SinricPro\r\n"); }); 
+  SinricPro.onDisconnected([](){ SINRICPRO_PRINTF("Disconnected from SinricPro\r\n"); });
   SinricPro.begin(APP_KEY, APP_SECRET);
 }
 
 void setup() {
-  Serial.begin(BAUD_RATE); Serial.printf("\r\n\r\n");
+  Serial.begin(BAUD_RATE); SINRICPRO_PRINTF("\r\n\r\n");
   setupWiFi();
   setupSinricPro();
 }

--- a/examples/Lock/Lock/Lock.ino
+++ b/examples/Lock/Lock/Lock.ino
@@ -25,6 +25,13 @@
   #include <ESP8266WiFi.h>
 #elif defined(ESP32) || defined(ARDUINO_ARCH_RP2040)
   #include <WiFi.h>
+#elif defined(ARDUINO_SAMD_MKRWIFI1010) || defined(ARDUINO_SAMD_NANO_33_IOT)
+  #include <WiFiNINA.h>
+#elif defined(ARDUINO_UNOWIFIR4) || defined(ARDUINO_MINIMA)
+  #include <WiFiS3.h>
+  #ifndef SINRICPRO_NOSSL
+    #define SINRICPRO_NOSSL
+  #endif
 #endif
 
 #include "SinricPro.h"

--- a/examples/Lock/Lock_with_feedback/Lock_with_feedback.ino
+++ b/examples/Lock/Lock_with_feedback/Lock_with_feedback.ino
@@ -52,7 +52,7 @@
 #if defined(ESP8266)
   #define LOCK_PIN          D1                       // PIN where the lock is connected to: HIGH = locked, LOW = unlocked
   #define LOCK_STATE_PIN    D2                       // PIN where the lock feedback is connected to (HIGH:locked, LOW:unlocked)
-#elif defined(ESP32) || defined(ARDUINO_ARCH_RP2040)
+#else
   #define LOCK_PIN          16                       // PIN where the lock is connected to: HIGH = locked, LOW = unlocked
   #define LOCK_STATE_PIN    17                       // PIN where the lock feedback is connected to (HIGH:locked, LOW:unlocked)
 #endif

--- a/examples/Lock/Lock_with_feedback/Lock_with_feedback.ino
+++ b/examples/Lock/Lock_with_feedback/Lock_with_feedback.ino
@@ -60,7 +60,7 @@
 bool lastLockState;
 
 bool onLockState(String deviceId, bool &lockState) {
-  Serial.printf("Device %s is %s\r\n", deviceId.c_str(), lockState?"locked":"unlocked");
+  SINRICPRO_PRINTF("Device %s is %s\r\n", deviceId.c_str(), lockState?"locked":"unlocked");
   digitalWrite(LOCK_PIN, lockState);  
   return true;
 }
@@ -68,17 +68,17 @@ bool onLockState(String deviceId, bool &lockState) {
 void checkLockState() {
   bool currentLockState = digitalRead(LOCK_STATE_PIN);                                    // get current lock state
   if (currentLockState == lastLockState) return;                                          // do nothing if state didn't changed
-  Serial.printf("Lock has been %s manually\r\n", currentLockState?"locked":"unlocked");   // print current lock state to serial
+  SINRICPRO_PRINTF("Lock has been %s manually\r\n", currentLockState?"locked":"unlocked");   // print current lock state to serial
   lastLockState = currentLockState;                                                       // update last known lock state
   SinricProLock &myLock = SinricPro[LOCK_ID];                                             // get the LockDevice
   bool success = myLock.sendLockStateEvent(currentLockState);                             // update LockState on Server
   if(!success) {
-      Serial.printf("Something went wrong...could not send Event to server!\r\n");
+      SINRICPRO_PRINTF("Something went wrong...could not send Event to server!\r\n");
   }
 }
 
 void setupWiFi() {
-  Serial.printf("\r\n[Wifi]: Connecting");
+  SINRICPRO_PRINTF("\r\n[Wifi]: Connecting");
   WiFi.begin(WIFI_SSID, WIFI_PASS);
 
   #if defined(ESP8266)
@@ -88,10 +88,10 @@ void setupWiFi() {
   #endif
 
   while (WiFi.status() != WL_CONNECTED) {
-    Serial.printf(".");
+    SINRICPRO_PRINTF(".");
     delay(250);
   }
-  Serial.printf("connected!\r\n[WiFi]: IP-Address is %s\r\n", WiFi.localIP().toString().c_str());
+  SINRICPRO_PRINTF("connected!\r\n[WiFi]: IP-Address is %s\r\n", WiFi.localIP().toString().c_str());
 }
 
 void setupSinricPro() {
@@ -99,13 +99,13 @@ void setupSinricPro() {
   myLock.onLockState(onLockState);
 
   // setup SinricPro
-  SinricPro.onConnected([](){ Serial.printf("Connected to SinricPro\r\n"); }); 
-  SinricPro.onDisconnected([](){ Serial.printf("Disconnected from SinricPro\r\n"); });
+  SinricPro.onConnected([](){ SINRICPRO_PRINTF("Connected to SinricPro\r\n"); }); 
+  SinricPro.onDisconnected([](){ SINRICPRO_PRINTF("Disconnected from SinricPro\r\n"); });
   SinricPro.begin(APP_KEY, APP_SECRET);
 }
 
 void setup() {
-  Serial.begin(BAUD_RATE); Serial.printf("\r\n\r\n");
+  Serial.begin(BAUD_RATE); SINRICPRO_PRINTF("\r\n\r\n");
 
   pinMode(LOCK_PIN, OUTPUT);
   pinMode(LOCK_STATE_PIN, INPUT);

--- a/examples/Lock/Lock_with_feedback/Lock_with_feedback.ino
+++ b/examples/Lock/Lock_with_feedback/Lock_with_feedback.ino
@@ -30,6 +30,13 @@
   #include <ESP8266WiFi.h>
 #elif defined(ESP32) || defined(ARDUINO_ARCH_RP2040)
   #include <WiFi.h>
+#elif defined(ARDUINO_SAMD_MKRWIFI1010) || defined(ARDUINO_SAMD_NANO_33_IOT)
+  #include <WiFiNINA.h>
+#elif defined(ARDUINO_UNOWIFIR4) || defined(ARDUINO_MINIMA)
+  #include <WiFiS3.h>
+  #ifndef SINRICPRO_NOSSL
+    #define SINRICPRO_NOSSL
+  #endif
 #endif
 
 #include "SinricPro.h"

--- a/examples/MotionSensor/MotionSensor.ino
+++ b/examples/MotionSensor/MotionSensor.ino
@@ -70,20 +70,20 @@ void handleMotionsensor() {
   bool actualMotionState = digitalRead(MOTIONSENSOR_PIN);   // read actual state of motion sensor
 
   if (actualMotionState != lastMotionState) {         // if state has changed
-    Serial.printf("Motion %s\r\n", actualMotionState?"detected":"not detected");
+    SINRICPRO_PRINTF("Motion %s\r\n", actualMotionState?"detected":"not detected");
     lastMotionState = actualMotionState;              // update last known state
     lastChange = actualMillis;                        // update debounce time
     SinricProMotionsensor &myMotionsensor = SinricPro[MOTIONSENSOR_ID]; // get motion sensor device
     bool success = myMotionsensor.sendMotionEvent(actualMotionState);
     if(!success) {
-      Serial.printf("Something went wrong...could not send Event to server!\r\n");
+      SINRICPRO_PRINTF("Something went wrong...could not send Event to server!\r\n");
     }
   }
 }
 
 // setup function for WiFi connection
 void setupWiFi() {
-  Serial.printf("\r\n[Wifi]: Connecting");
+  SINRICPRO_PRINTF("\r\n[Wifi]: Connecting");
 
   #if defined(ESP8266)
     WiFi.setSleepMode(WIFI_NONE_SLEEP); 
@@ -96,11 +96,11 @@ void setupWiFi() {
   WiFi.begin(WIFI_SSID, WIFI_PASS);
 
   while (WiFi.status() != WL_CONNECTED) {
-    Serial.printf(".");
+    SINRICPRO_PRINTF(".");
     delay(250);
   }
   IPAddress localIP = WiFi.localIP();
-  Serial.printf("connected!\r\n[WiFi]: IP-Address is %d.%d.%d.%d\r\n", localIP[0], localIP[1], localIP[2], localIP[3]);
+  SINRICPRO_PRINTF("connected!\r\n[WiFi]: IP-Address is %d.%d.%d.%d\r\n", localIP[0], localIP[1], localIP[2], localIP[3]);
 }
 
 // setup function for SinricPro
@@ -109,14 +109,14 @@ void setupSinricPro() {
   SinricProMotionsensor& myMotionsensor = SinricPro[MOTIONSENSOR_ID];
 
   // setup SinricPro
-  SinricPro.onConnected([](){ Serial.printf("Connected to SinricPro\r\n"); });
-  SinricPro.onDisconnected([](){ Serial.printf("Disconnected from SinricPro\r\n"); });
+  SinricPro.onConnected([](){ SINRICPRO_PRINTF("Connected to SinricPro\r\n"); });
+  SinricPro.onDisconnected([](){ SINRICPRO_PRINTF("Disconnected from SinricPro\r\n"); });
   SinricPro.begin(APP_KEY, APP_SECRET);
 }
 
 // main setup function
 void setup() {
-  Serial.begin(BAUD_RATE); Serial.printf("\r\n\r\n");
+  Serial.begin(BAUD_RATE); SINRICPRO_PRINTF("\r\n\r\n");
 
   pinMode(MOTIONSENSOR_PIN, INPUT);
 

--- a/examples/MotionSensor/MotionSensor.ino
+++ b/examples/MotionSensor/MotionSensor.ino
@@ -28,6 +28,13 @@
   #include <ESP8266WiFi.h>
 #elif defined(ESP32) || defined(ARDUINO_ARCH_RP2040)
   #include <WiFi.h>
+#elif defined(ARDUINO_SAMD_MKRWIFI1010) || defined(ARDUINO_SAMD_NANO_33_IOT)
+  #include <WiFiNINA.h>
+#elif defined(ARDUINO_UNOWIFIR4) || defined(ARDUINO_MINIMA)
+  #include <WiFiS3.h>
+  #ifndef SINRICPRO_NOSSL
+    #define SINRICPRO_NOSSL
+  #endif
 #endif
 
 #include "SinricPro.h"

--- a/examples/OTAUpdate/OTAUpdate.ino
+++ b/examples/OTAUpdate/OTAUpdate.ino
@@ -31,11 +31,20 @@
 #if defined(ESP8266)
   #include <ESP8266WiFi.h>
   #include "ESP8266OTAHelper.h"
-#elif defined(ESP32) 
+#elif defined(ESP32)
   #include <WiFi.h>
   #include "ESP32OTAHelper.h"
-#elif defined(ARDUINO_ARCH_RP2040) 
+#elif defined(ARDUINO_ARCH_RP2040)
   #include <WiFi.h>
+  #include "ESP8266OTAHelper.h"
+#elif defined(ARDUINO_SAMD_MKRWIFI1010) || defined(ARDUINO_SAMD_NANO_33_IOT)
+  #include <WiFiNINA.h>
+  #include "ESP8266OTAHelper.h"
+#elif defined(ARDUINO_UNOWIFIR4) || defined(ARDUINO_MINIMA)
+  #include <WiFiS3.h>
+  #ifndef SINRICPRO_NOSSL
+    #define SINRICPRO_NOSSL
+  #endif
   #include "ESP8266OTAHelper.h"
 #endif
 

--- a/examples/OTAUpdate/OTAUpdate.ino
+++ b/examples/OTAUpdate/OTAUpdate.ino
@@ -96,7 +96,7 @@ bool handleOTAUpdate(const String& url, int major, int minor, int patch, bool fo
 
 // setup function for WiFi connection
 void setupWiFi() {
-  Serial.printf("\r\n[Wifi]: Connecting");
+  SINRICPRO_PRINTF("\r\n[Wifi]: Connecting");
 
 #if defined(ESP8266)
   WiFi.setSleepMode(WIFI_NONE_SLEEP);
@@ -109,11 +109,11 @@ void setupWiFi() {
   WiFi.begin(WIFI_SSID, WIFI_PASS);
 
   while (WiFi.status() != WL_CONNECTED) {
-    Serial.printf(".");
+    SINRICPRO_PRINTF(".");
     delay(250);
   }
 
-  Serial.printf("connected!\r\n[WiFi]: IP-Address is %s\r\n", WiFi.localIP().toString().c_str());
+  SINRICPRO_PRINTF("connected!\r\n[WiFi]: IP-Address is %s\r\n", WiFi.localIP().toString().c_str());
 }
 
 // setup function for SinricPro
@@ -122,10 +122,10 @@ void setupSinricPro() {
 
   // setup SinricPro
   SinricPro.onConnected([]() {
-    Serial.printf("Connected to SinricPro\r\n");
+    SINRICPRO_PRINTF("Connected to SinricPro\r\n");
   });
   SinricPro.onDisconnected([]() {
-    Serial.printf("Disconnected from SinricPro\r\n");
+    SINRICPRO_PRINTF("Disconnected from SinricPro\r\n");
   });
   SinricPro.onOTAUpdate(handleOTAUpdate);
   SinricPro.begin(APP_KEY, APP_SECRET);
@@ -134,7 +134,7 @@ void setupSinricPro() {
 // main setup function
 void setup() {
   Serial.begin(BAUD_RATE);
-  Serial.printf("\r\n\r\n");
+  SINRICPRO_PRINTF("\r\n\r\n");
   setupWiFi();
   setupSinricPro();
 }

--- a/examples/OTAUpdate/OTAUpdate.ino
+++ b/examples/OTAUpdate/OTAUpdate.ino
@@ -20,6 +20,10 @@
 
 // Sketch -> Export Compiled Binary to export
 
+// WARNNING: The ESP8266 chip has limited memory. 
+// While basic sketches can usually perform OTA updates successfully, 
+// more complex use cases may cause the update to fail due to memory constraints.
+
 #ifdef ENABLE_DEBUG
   #define DEBUG_ESP_PORT Serial
   #define NODEBUG_WEBSOCKETS
@@ -116,9 +120,15 @@ void setupWiFi() {
   SINRICPRO_PRINTF("connected!\r\n[WiFi]: IP-Address is %s\r\n", WiFi.localIP().toString().c_str());
 }
 
+bool onPowerState(const String &deviceId, bool &state) {
+  SINRICPRO_PRINTF("Device %s turned %s (via SinricPro) \r\n", deviceId.c_str(), state?"on":"off");
+  return true; // request handled properly
+}
+
 // setup function for SinricPro
 void setupSinricPro() {
-   SinricProSwitch& mySwitch = SinricPro[SWITCH_ID];
+  SinricProSwitch& mySwitch = SinricPro[SWITCH_ID];
+  mySwitch.onPowerState(onPowerState);
 
   // setup SinricPro
   SinricPro.onConnected([]() {

--- a/examples/PowerSensor/PowerSensor.ino
+++ b/examples/PowerSensor/PowerSensor.ino
@@ -82,12 +82,12 @@ void sendPowerSensorData() {
   SinricProPowerSensor &myPowerSensor = SinricPro[POWERSENSOR_ID];
   bool success = myPowerSensor.sendPowerSensorEvent(powerMeasure.voltage, powerMeasure.current, powerMeasure.power, powerMeasure.apparentPower);
   if(!success) {
-    Serial.printf("Something went wrong...could not send Event to server!\r\n");
+    SINRICPRO_PRINTF("Something went wrong...could not send Event to server!\r\n");
   }
 }
 
 void setupWiFi() {
-  Serial.printf("\r\n[Wifi]: Connecting");
+  SINRICPRO_PRINTF("\r\n[Wifi]: Connecting");
   
   #if defined(ESP8266)
     WiFi.setSleepMode(WIFI_NONE_SLEEP); 
@@ -100,11 +100,11 @@ void setupWiFi() {
   WiFi.begin(WIFI_SSID, WIFI_PASS);
 
   while (WiFi.status() != WL_CONNECTED) {
-    Serial.printf(".");
+    SINRICPRO_PRINTF(".");
     delay(250);
   }
   IPAddress localIP = WiFi.localIP();
-  Serial.printf("connected!\r\n[WiFi]: IP-Address is %s\r\n", WiFi.localIP().toString().c_str());
+  SINRICPRO_PRINTF("connected!\r\n[WiFi]: IP-Address is %s\r\n", WiFi.localIP().toString().c_str());
 }
 
 void setupSinricPro() {
@@ -112,8 +112,8 @@ void setupSinricPro() {
 
   // setup SinricPro
   //SinricPro.restoreDeviceStates(true); // Uncomment to restore the last known state from the server.
-  SinricPro.onConnected([](){ Serial.printf("Connected to SinricPro\r\n"); }); 
-  SinricPro.onDisconnected([](){ Serial.printf("Disconnected from SinricPro\r\n"); });
+  SinricPro.onConnected([](){ SINRICPRO_PRINTF("Connected to SinricPro\r\n"); }); 
+  SinricPro.onDisconnected([](){ SINRICPRO_PRINTF("Disconnected from SinricPro\r\n"); });
   SinricPro.begin(APP_KEY, APP_SECRET);
 }
 

--- a/examples/PowerSensor/PowerSensor.ino
+++ b/examples/PowerSensor/PowerSensor.ino
@@ -27,6 +27,13 @@
   #include <ESP8266WiFi.h>
 #elif defined(ESP32) || defined(ARDUINO_ARCH_RP2040)
   #include <WiFi.h>
+#elif defined(ARDUINO_SAMD_MKRWIFI1010) || defined(ARDUINO_SAMD_NANO_33_IOT)
+  #include <WiFiNINA.h>
+#elif defined(ARDUINO_UNOWIFIR4) || defined(ARDUINO_MINIMA)
+  #include <WiFiS3.h>
+  #ifndef SINRICPRO_NOSSL
+    #define SINRICPRO_NOSSL
+  #endif
 #endif
 
 #include "SinricPro.h"

--- a/examples/Relay/MultiRelays_advance/MultiRelays_advance.ino
+++ b/examples/Relay/MultiRelays_advance/MultiRelays_advance.ino
@@ -25,6 +25,13 @@
   #include <ESP8266WiFi.h>
 #elif defined(ESP32) || defined(ARDUINO_ARCH_RP2040)
   #include <WiFi.h>
+#elif defined(ARDUINO_SAMD_MKRWIFI1010) || defined(ARDUINO_SAMD_NANO_33_IOT)
+  #include <WiFiNINA.h>
+#elif defined(ARDUINO_UNOWIFIR4) || defined(ARDUINO_MINIMA)
+  #include <WiFiS3.h>
+  #ifndef SINRICPRO_NOSSL
+    #define SINRICPRO_NOSSL
+  #endif
 #endif
 
 #include <SinricPro.h>

--- a/examples/Relay/MultiRelays_advance/MultiRelays_advance.ino
+++ b/examples/Relay/MultiRelays_advance/MultiRelays_advance.ino
@@ -102,7 +102,7 @@ std::vector<RelayInfo> relays = {
 bool onPowerState(const String &deviceId, bool &state) {
   for (auto &relay : relays) {                                                            // for each relay configuration
     if (deviceId == relay.deviceId) {                                                       // check if deviceId matches
-      Serial.printf("Device %s turned %s\r\n", relay.name.c_str(), state ? "on" : "off");     // print relay name and state to serial
+      SINRICPRO_PRINTF("Device %s turned %s\r\n", relay.name.c_str(), state ? "on" : "off");     // print relay name and state to serial
       digitalWrite(relay.pin, state);                                                         // set state to digital pin / gpio
       return true;                                                                            // return with success true
     }
@@ -117,7 +117,7 @@ void setupRelayPins() {
 }
 
 void setupWiFi() {
-  Serial.printf("\r\n[Wifi]: Connecting");
+  SINRICPRO_PRINTF("\r\n[Wifi]: Connecting");
   WiFi.begin(WIFI_SSID, WIFI_PASS);
 
   #if defined(ESP8266)
@@ -127,10 +127,10 @@ void setupWiFi() {
   #endif
 
   while (WiFi.status() != WL_CONNECTED) {
-    Serial.printf(".");
+    SINRICPRO_PRINTF(".");
     delay(250);
   }
-  Serial.printf("connected!\r\n[WiFi]: IP-Address is %s\r\n", WiFi.localIP().toString().c_str());
+  SINRICPRO_PRINTF("connected!\r\n[WiFi]: IP-Address is %s\r\n", WiFi.localIP().toString().c_str());
 }
 
 void setupSinricPro() {
@@ -139,8 +139,8 @@ void setupSinricPro() {
     mySwitch.onPowerState(onPowerState);                     // attach onPowerState callback to the new device
   }
 
-  SinricPro.onConnected([]() { Serial.printf("Connected to SinricPro\r\n"); });
-  SinricPro.onDisconnected([]() { Serial.printf("Disconnected from SinricPro\r\n"); });
+  SinricPro.onConnected([]() { SINRICPRO_PRINTF("Connected to SinricPro\r\n"); });
+  SinricPro.onDisconnected([]() { SINRICPRO_PRINTF("Disconnected from SinricPro\r\n"); });
 
   SinricPro.begin(APP_KEY, APP_SECRET);
 }

--- a/examples/Relay/MultiRelays_advance/MultiRelays_advance.ino
+++ b/examples/Relay/MultiRelays_advance/MultiRelays_advance.ino
@@ -46,7 +46,7 @@
   #define RELAYPIN_6 D6
   #define RELAYPIN_7 D7
   #define RELAYPIN_8 D8
-#elif defined(ESP32) || defined(ARDUINO_ARCH_RP2040)
+#else
   #define RELAYPIN_1 16
   #define RELAYPIN_2 17
   #define RELAYPIN_3 18

--- a/examples/Relay/Relay/Relay.ino
+++ b/examples/Relay/Relay/Relay.ino
@@ -44,7 +44,7 @@
 
 #if defined(ESP8266)
   #define RELAY_PIN         D5                  // Pin where the relay is connected (D5 = GPIO 14 on ESP8266)
-#elif defined(ESP32) || defined(ARDUINO_ARCH_RP2040)
+#else
   #define RELAY_PIN         16                  // Pin where the relay is connected (GPIO 16 on ESP32)
 #endif
 

--- a/examples/Relay/Relay/Relay.ino
+++ b/examples/Relay/Relay/Relay.ino
@@ -23,6 +23,13 @@
   #include <ESP8266WiFi.h>
 #elif defined(ESP32) || defined(ARDUINO_ARCH_RP2040)
   #include <WiFi.h>
+#elif defined(ARDUINO_SAMD_MKRWIFI1010) || defined(ARDUINO_SAMD_NANO_33_IOT)
+  #include <WiFiNINA.h>
+#elif defined(ARDUINO_UNOWIFIR4) || defined(ARDUINO_MINIMA)
+  #include <WiFiS3.h>
+  #ifndef SINRICPRO_NOSSL
+    #define SINRICPRO_NOSSL
+  #endif
 #endif
 
 #include "SinricPro.h"

--- a/examples/Settings/MultiWiFi/MultiWiFi.ino
+++ b/examples/Settings/MultiWiFi/MultiWiFi.ino
@@ -64,13 +64,13 @@ SinricProWiFiSettings spws(LittleFS, primarySSID, primaryPassword, secondarySSID
 
 bool onSetModuleSetting(const String& id, SettingValue& value) {
   // Handle module settings.
-  if (!std::holds_alternative<String>(value)) {
+  if (!value.holds<String>()) {
     Serial.println(F("onSetModuleSetting: Expected string value"));
     return false;
   }
 
   JsonDocument doc;
-  DeserializationError error = deserializeJson(doc, std::get<String>(value));
+  DeserializationError error = deserializeJson(doc, value.get<String>());
 
   if (error) {
     Serial.print(F("onSetModuleSetting::deserializeJson() failed: "));

--- a/examples/Settings/MultiWiFi/MultiWiFi.ino
+++ b/examples/Settings/MultiWiFi/MultiWiFi.ino
@@ -26,6 +26,15 @@
 #include <ESP8266WiFi.h>
 #elif defined(ESP32)
 #include <WiFi.h>
+#elif defined(ARDUINO_ARCH_RP2040)
+#include <WiFi.h>
+#elif defined(ARDUINO_SAMD_MKRWIFI1010) || defined(ARDUINO_SAMD_NANO_33_IOT)
+#include <WiFiNINA.h>
+#elif defined(ARDUINO_UNOWIFIR4) || defined(ARDUINO_MINIMA)
+#include <WiFiS3.h>
+#ifndef SINRICPRO_NOSSL
+#define SINRICPRO_NOSSL
+#endif
 #endif
 
 #include <LittleFS.h>

--- a/examples/Settings/MultiWiFi/MultiWiFi.ino
+++ b/examples/Settings/MultiWiFi/MultiWiFi.ino
@@ -113,7 +113,7 @@ bool setupLittleFS() {
 
 // setup function for WiFi connection
 void setupWiFi() {
-  Serial.printf("\r\n[Wifi]: Connecting");
+  SINRICPRO_PRINTF("\r\n[Wifi]: Connecting");
 
   // Load settings from file or using defaults if loading fails.
   spws.begin();
@@ -168,10 +168,10 @@ void setupSinricPro() {
 
   // setup SinricPro
   SinricPro.onConnected([]() {
-    Serial.printf("Connected to SinricPro\r\n");
+    SINRICPRO_PRINTF("Connected to SinricPro\r\n");
   });
   SinricPro.onDisconnected([]() {
-    Serial.printf("Disconnected from SinricPro\r\n");
+    SINRICPRO_PRINTF("Disconnected from SinricPro\r\n");
   });
 
   SinricPro.onSetSetting(onSetModuleSetting);
@@ -181,7 +181,7 @@ void setupSinricPro() {
 // main setup function
 void setup() {
   Serial.begin(BAUD_RATE);
-  Serial.printf("\r\n\r\n");
+  SINRICPRO_PRINTF("\r\n\r\n");
   setupLittleFS();
   setupWiFi();
   setupSinricPro();

--- a/examples/Settings/SetFixedIPAddress/SetFixedIPAddress.ino
+++ b/examples/Settings/SetFixedIPAddress/SetFixedIPAddress.ino
@@ -72,7 +72,7 @@ bool onSetModuleSetting(const String &id, SettingValue &value) {
     String dns2 = doc["dns2"] | "";
 
     // Change your WiFi config here.
-    Serial.printf("localIP:%s, gateway:%s, subnet:%s, dns1:%s, dns2:%s   \r\n", localIP.c_str(), gateway.c_str(), subnet.c_str(), dns1.c_str(), dns2.c_str());
+    SINRICPRO_PRINTF("localIP:%s, gateway:%s, subnet:%s, dns1:%s, dns2:%s   \r\n", localIP.c_str(), gateway.c_str(), subnet.c_str(), dns1.c_str(), dns2.c_str());
     return true;
   } else {
     return false;
@@ -81,7 +81,7 @@ bool onSetModuleSetting(const String &id, SettingValue &value) {
 
 // setup function for WiFi connection
 void setupWiFi() {
-  Serial.printf("\r\n[Wifi]: Connecting");
+  SINRICPRO_PRINTF("\r\n[Wifi]: Connecting");
 
 #if defined(ESP8266)
   WiFi.setSleepMode(WIFI_NONE_SLEEP);
@@ -94,10 +94,10 @@ void setupWiFi() {
   WiFi.begin(WIFI_SSID, WIFI_PASS);
 
   while (WiFi.status() != WL_CONNECTED) {
-    Serial.printf(".");
+    SINRICPRO_PRINTF(".");
     delay(250);
   }
-  Serial.printf("connected!\r\n[WiFi]: IP-Address is %s\r\n", WiFi.localIP().toString().c_str());
+  SINRICPRO_PRINTF("connected!\r\n[WiFi]: IP-Address is %s\r\n", WiFi.localIP().toString().c_str());
 }
 
 // setup function for SinricPro
@@ -106,10 +106,10 @@ void setupSinricPro() {
 
   // setup SinricPro
   SinricPro.onConnected([]() {
-    Serial.printf("Connected to SinricPro\r\n");
+    SINRICPRO_PRINTF("Connected to SinricPro\r\n");
   });
   SinricPro.onDisconnected([]() {
-    Serial.printf("Disconnected from SinricPro\r\n");
+    SINRICPRO_PRINTF("Disconnected from SinricPro\r\n");
   });
 
   SinricPro.onSetSetting(onSetModuleSetting);
@@ -119,7 +119,7 @@ void setupSinricPro() {
 // main setup function
 void setup() {
   Serial.begin(BAUD_RATE);
-  Serial.printf("\r\n\r\n");
+  SINRICPRO_PRINTF("\r\n\r\n");
   setupWiFi();
   setupSinricPro();
 }

--- a/examples/Settings/SetFixedIPAddress/SetFixedIPAddress.ino
+++ b/examples/Settings/SetFixedIPAddress/SetFixedIPAddress.ino
@@ -25,6 +25,13 @@
 #include <ESP8266WiFi.h>
 #elif defined(ESP32) || defined(ARDUINO_ARCH_RP2040)
 #include <WiFi.h>
+#elif defined(ARDUINO_SAMD_MKRWIFI1010) || defined(ARDUINO_SAMD_NANO_33_IOT)
+#include <WiFiNINA.h>
+#elif defined(ARDUINO_UNOWIFIR4) || defined(ARDUINO_MINIMA)
+#include <WiFiS3.h>
+#ifndef SINRICPRO_NOSSL
+#define SINRICPRO_NOSSL
+#endif
 #endif
 
 #include "SinricPro.h"

--- a/examples/Settings/SetFixedIPAddress/SetFixedIPAddress.ino
+++ b/examples/Settings/SetFixedIPAddress/SetFixedIPAddress.ino
@@ -50,13 +50,13 @@
 
 bool onSetModuleSetting(const String &id, SettingValue &value) {
   // Handle module settings.
-  if (!std::holds_alternative<String>(value)) {
+  if (!value.holds<String>()) {
     Serial.println(F("onSetModuleSetting: Expected string value"));
     return false;
   }
 
   JsonDocument doc;
-  DeserializationError error = deserializeJson(doc, std::get<String>(value));
+  DeserializationError error = deserializeJson(doc, value.get<String>());
 
   if (error) {
     Serial.print(F("onSetModuleSetting::deserializeJson() failed: "));

--- a/examples/Settings/Settings/Settings.ino
+++ b/examples/Settings/Settings/Settings.ino
@@ -25,6 +25,13 @@
 #include <ESP8266WiFi.h>
 #elif defined(ESP32) || defined(ARDUINO_ARCH_RP2040)
 #include <WiFi.h>
+#elif defined(ARDUINO_SAMD_MKRWIFI1010) || defined(ARDUINO_SAMD_NANO_33_IOT)
+#include <WiFiNINA.h>
+#elif defined(ARDUINO_UNOWIFIR4) || defined(ARDUINO_MINIMA)
+#include <WiFiS3.h>
+#ifndef SINRICPRO_NOSSL
+#define SINRICPRO_NOSSL
+#endif
 #endif
 
 #include "SinricPro.h"

--- a/examples/Settings/Settings/Settings.ino
+++ b/examples/Settings/Settings/Settings.ino
@@ -49,13 +49,13 @@
 bool onSetDeviceSetting(const String& deviceId, const String& settingId, SettingValue& settingValue) {
   // Handle device settings based on value type
   if (std::holds_alternative<int>(settingValue)) {
-    Serial.printf("Device %s: Setting %s = %d\r\n", deviceId.c_str(), settingId.c_str(), std::get<int>(settingValue));
+    SINRICPRO_PRINTF("Device %s: Setting %s = %d\r\n", deviceId.c_str(), settingId.c_str(), std::get<int>(settingValue));
   } else if (std::holds_alternative<float>(settingValue)) {
-    Serial.printf("Device %s: Setting %s = %.2f\r\n", deviceId.c_str(), settingId.c_str(), std::get<float>(settingValue));
+    SINRICPRO_PRINTF("Device %s: Setting %s = %.2f\r\n", deviceId.c_str(), settingId.c_str(), std::get<float>(settingValue));
   } else if (std::holds_alternative<bool>(settingValue)) {
-    Serial.printf("Device %s: Setting %s = %s\r\n", deviceId.c_str(), settingId.c_str(), std::get<bool>(settingValue) ? "true" : "false");
+    SINRICPRO_PRINTF("Device %s: Setting %s = %s\r\n", deviceId.c_str(), settingId.c_str(), std::get<bool>(settingValue) ? "true" : "false");
   } else if (std::holds_alternative<String>(settingValue)) {
-    Serial.printf("Device %s: Setting %s = %s\r\n", deviceId.c_str(), settingId.c_str(), std::get<String>(settingValue).c_str());
+    SINRICPRO_PRINTF("Device %s: Setting %s = %s\r\n", deviceId.c_str(), settingId.c_str(), std::get<String>(settingValue).c_str());
   }
   return true;
 }
@@ -63,20 +63,20 @@ bool onSetDeviceSetting(const String& deviceId, const String& settingId, Setting
 bool onSetModuleSetting(const String& id, SettingValue& value) {
   // Handle module settings based on value type
   if (std::holds_alternative<int>(value)) {
-    Serial.printf("Module setting %s = %d\r\n", id.c_str(), std::get<int>(value));
+    SINRICPRO_PRINTF("Module setting %s = %d\r\n", id.c_str(), std::get<int>(value));
   } else if (std::holds_alternative<float>(value)) {
-    Serial.printf("Module setting %s = %.2f\r\n", id.c_str(), std::get<float>(value));
+    SINRICPRO_PRINTF("Module setting %s = %.2f\r\n", id.c_str(), std::get<float>(value));
   } else if (std::holds_alternative<bool>(value)) {
-    Serial.printf("Module setting %s = %s\r\n", id.c_str(), std::get<bool>(value) ? "true" : "false");
+    SINRICPRO_PRINTF("Module setting %s = %s\r\n", id.c_str(), std::get<bool>(value) ? "true" : "false");
   } else if (std::holds_alternative<String>(value)) {
-    Serial.printf("Module setting %s = %s\r\n", id.c_str(), std::get<String>(value).c_str());
+    SINRICPRO_PRINTF("Module setting %s = %s\r\n", id.c_str(), std::get<String>(value).c_str());
   }
   return true;
 }
 
 // setup function for WiFi connection
 void setupWiFi() {
-  Serial.printf("\r\n[Wifi]: Connecting");
+  SINRICPRO_PRINTF("\r\n[Wifi]: Connecting");
 
 #if defined(ESP8266)
   WiFi.setSleepMode(WIFI_NONE_SLEEP);
@@ -89,10 +89,10 @@ void setupWiFi() {
   WiFi.begin(WIFI_SSID, WIFI_PASS);
 
   while (WiFi.status() != WL_CONNECTED) {
-    Serial.printf(".");
+    SINRICPRO_PRINTF(".");
     delay(250);
   }
-  Serial.printf("connected!\r\n[WiFi]: IP-Address is %s\r\n", WiFi.localIP().toString().c_str());
+  SINRICPRO_PRINTF("connected!\r\n[WiFi]: IP-Address is %s\r\n", WiFi.localIP().toString().c_str());
 }
 
 // setup function for SinricPro
@@ -102,10 +102,10 @@ void setupSinricPro() {
 
   // setup SinricPro
   SinricPro.onConnected([]() {
-    Serial.printf("Connected to SinricPro\r\n");
+    SINRICPRO_PRINTF("Connected to SinricPro\r\n");
   });
   SinricPro.onDisconnected([]() {
-    Serial.printf("Disconnected from SinricPro\r\n");
+    SINRICPRO_PRINTF("Disconnected from SinricPro\r\n");
   });
 
   SinricPro.onSetSetting(onSetModuleSetting);
@@ -115,7 +115,7 @@ void setupSinricPro() {
 // main setup function
 void setup() {
   Serial.begin(BAUD_RATE);
-  Serial.printf("\r\n\r\n");
+  SINRICPRO_PRINTF("\r\n\r\n");
   setupWiFi();
   setupSinricPro();
 }

--- a/examples/Settings/Settings/Settings.ino
+++ b/examples/Settings/Settings/Settings.ino
@@ -48,28 +48,28 @@
 
 bool onSetDeviceSetting(const String& deviceId, const String& settingId, SettingValue& settingValue) {
   // Handle device settings based on value type
-  if (std::holds_alternative<int>(settingValue)) {
-    SINRICPRO_PRINTF("Device %s: Setting %s = %d\r\n", deviceId.c_str(), settingId.c_str(), std::get<int>(settingValue));
-  } else if (std::holds_alternative<float>(settingValue)) {
-    SINRICPRO_PRINTF("Device %s: Setting %s = %.2f\r\n", deviceId.c_str(), settingId.c_str(), std::get<float>(settingValue));
-  } else if (std::holds_alternative<bool>(settingValue)) {
-    SINRICPRO_PRINTF("Device %s: Setting %s = %s\r\n", deviceId.c_str(), settingId.c_str(), std::get<bool>(settingValue) ? "true" : "false");
-  } else if (std::holds_alternative<String>(settingValue)) {
-    SINRICPRO_PRINTF("Device %s: Setting %s = %s\r\n", deviceId.c_str(), settingId.c_str(), std::get<String>(settingValue).c_str());
+  if (settingValue.holds<int>()) {
+    SINRICPRO_PRINTF("Device %s: Setting %s = %d\r\n", deviceId.c_str(), settingId.c_str(), settingValue.get<int>());
+  } else if (settingValue.holds<float>()) {
+    SINRICPRO_PRINTF("Device %s: Setting %s = %.2f\r\n", deviceId.c_str(), settingId.c_str(), settingValue.get<float>());
+  } else if (settingValue.holds<bool>()) {
+    SINRICPRO_PRINTF("Device %s: Setting %s = %s\r\n", deviceId.c_str(), settingId.c_str(), settingValue.get<bool>() ? "true" : "false");
+  } else if (settingValue.holds<String>()) {
+    SINRICPRO_PRINTF("Device %s: Setting %s = %s\r\n", deviceId.c_str(), settingId.c_str(), settingValue.get<String>().c_str());
   }
   return true;
 }
 
 bool onSetModuleSetting(const String& id, SettingValue& value) {
   // Handle module settings based on value type
-  if (std::holds_alternative<int>(value)) {
-    SINRICPRO_PRINTF("Module setting %s = %d\r\n", id.c_str(), std::get<int>(value));
-  } else if (std::holds_alternative<float>(value)) {
-    SINRICPRO_PRINTF("Module setting %s = %.2f\r\n", id.c_str(), std::get<float>(value));
-  } else if (std::holds_alternative<bool>(value)) {
-    SINRICPRO_PRINTF("Module setting %s = %s\r\n", id.c_str(), std::get<bool>(value) ? "true" : "false");
-  } else if (std::holds_alternative<String>(value)) {
-    SINRICPRO_PRINTF("Module setting %s = %s\r\n", id.c_str(), std::get<String>(value).c_str());
+  if (value.holds<int>()) {
+    SINRICPRO_PRINTF("Module setting %s = %d\r\n", id.c_str(), value.get<int>());
+  } else if (value.holds<float>()) {
+    SINRICPRO_PRINTF("Module setting %s = %.2f\r\n", id.c_str(), value.get<float>());
+  } else if (value.holds<bool>()) {
+    SINRICPRO_PRINTF("Module setting %s = %s\r\n", id.c_str(), value.get<bool>() ? "true" : "false");
+  } else if (value.holds<String>()) {
+    SINRICPRO_PRINTF("Module setting %s = %s\r\n", id.c_str(), value.get<String>().c_str());
   }
   return true;
 }

--- a/examples/Speaker/Speaker.ino
+++ b/examples/Speaker/Speaker.ino
@@ -67,32 +67,32 @@ struct {
 
 // Speaker device callbacks
 bool onPowerState(const String &deviceId, bool &state) {
-  Serial.printf("Speaker turned %s\r\n", state?"on":"off");
+  SINRICPRO_PRINTF("Speaker turned %s\r\n", state?"on":"off");
   speakerState.power = state; // set powerState
   return true; 
 }
 
 bool onSetVolume(const String &deviceId, int &volume) {
-  Serial.printf("Volume set to:  %i\r\n", volume);
+  SINRICPRO_PRINTF("Volume set to:  %i\r\n", volume);
   speakerState.volume = volume; // update Volume
   return true;
 }
 
 bool onAdjustVolume(const String &deviceId, int &volumeDelta, bool volumeDefault) {
   speakerState.volume += volumeDelta;  // calcualte new absolute volume
-  Serial.printf("Volume changed about %i to %i\r\n", volumeDelta, speakerState.volume);
+  SINRICPRO_PRINTF("Volume changed about %i to %i\r\n", volumeDelta, speakerState.volume);
   volumeDelta = speakerState.volume; // return new absolute volume
   return true;
 }
 
 bool onMute(const String &deviceId, bool &mute) {
-  Serial.printf("Speaker is %s\r\n", mute?"muted":"unmuted");
+  SINRICPRO_PRINTF("Speaker is %s\r\n", mute?"muted":"unmuted");
   speakerState.muted = mute; // update muted state
   return true;
 }
 
 bool onMediaControl(const String &deviceId, String &control) {
-  Serial.printf("MediaControl: %s\r\n", control.c_str());
+  SINRICPRO_PRINTF("MediaControl: %s\r\n", control.c_str());
   if (control == "Play") {}           // do whatever you want to do here
   if (control == "Pause") {}          // do whatever you want to do here
   if (control == "Stop") {}           // do whatever you want to do here
@@ -105,12 +105,12 @@ bool onMediaControl(const String &deviceId, String &control) {
 }
 
 bool onSelectInput(const String &deviceId, String &input) {
-  Serial.printf("Input changed to %s\r\n", input.c_str());
+  SINRICPRO_PRINTF("Input changed to %s\r\n", input.c_str());
   return true;
 }
 
 bool onSetMode(const String &deviceId, String &mode) {
-  Serial.printf("Speaker mode set to %s\r\n", mode.c_str());
+  SINRICPRO_PRINTF("Speaker mode set to %s\r\n", mode.c_str());
   if (mode == "MOVIE") speakerState.mode = mode_movie;
   if (mode == "MUSIC") speakerState.mode = mode_music;
   if (mode == "NIGHT") speakerState.mode = mode_night;
@@ -120,7 +120,7 @@ bool onSetMode(const String &deviceId, String &mode) {
 }
 
 bool onSetBands(const String& deviceId, const String &bands, int &level) {
-  Serial.printf("Device %s bands %s set to %d\r\n", deviceId.c_str(), bands.c_str(), level);
+  SINRICPRO_PRINTF("Device %s bands %s set to %d\r\n", deviceId.c_str(), bands.c_str(), level);
   int index;
   if (bands == "BASS") index = BANDS_INDEX_BASS;
   if (bands == "MIDRANGE") index = BANDS_INDEX_MIDRANGE;
@@ -137,7 +137,7 @@ bool onAdjustBands(const String &deviceId, const String &bands, int &levelDelta)
   speakerState.bands[index] += levelDelta;
   levelDelta = speakerState.bands[index]; // return absolute trebble level
 
-  Serial.printf("Device %s bands \"%s\" adjusted about %i to %d\r\n", deviceId.c_str(), bands.c_str(), levelDelta, speakerState.bands[index]);
+  SINRICPRO_PRINTF("Device %s bands \"%s\" adjusted about %i to %d\r\n", deviceId.c_str(), bands.c_str(), levelDelta, speakerState.bands[index]);
   return true; // request handled properly
 }  
 
@@ -149,14 +149,14 @@ bool onResetBands(const String &deviceId, const String &bands, int &level) {
   speakerState.bands[index] = 0;
   level = speakerState.bands[index]; // return new level
 
-  Serial.printf("Device %s bands \"%s\" reset to%d\r\n", deviceId.c_str(), bands.c_str(), speakerState.bands[index]);
+  SINRICPRO_PRINTF("Device %s bands \"%s\" reset to%d\r\n", deviceId.c_str(), bands.c_str(), speakerState.bands[index]);
   return true; // request handled properly
 }  
 
 
 // setup function for WiFi connection
 void setupWiFi() {
-  Serial.printf("\r\n[Wifi]: Connecting");
+  SINRICPRO_PRINTF("\r\n[Wifi]: Connecting");
 
   #if defined(ESP8266)
     WiFi.setSleepMode(WIFI_NONE_SLEEP); 
@@ -169,11 +169,11 @@ void setupWiFi() {
   WiFi.begin(WIFI_SSID, WIFI_PASS); 
 
   while (WiFi.status() != WL_CONNECTED) {
-    Serial.printf(".");
+    SINRICPRO_PRINTF(".");
     delay(250);
   }
   IPAddress localIP = WiFi.localIP();
-  Serial.printf("connected!\r\n[WiFi]: IP-Address is %d.%d.%d.%d\r\n", localIP[0], localIP[1], localIP[2], localIP[3]);
+  SINRICPRO_PRINTF("connected!\r\n[WiFi]: IP-Address is %d.%d.%d.%d\r\n", localIP[0], localIP[1], localIP[2], localIP[3]);
 }
 
 // setup function for SinricPro
@@ -194,14 +194,14 @@ void setupSinricPro() {
   speaker.onSelectInput(onSelectInput);
 
   // setup SinricPro
-  SinricPro.onConnected([](){ Serial.printf("Connected to SinricPro\r\n"); }); 
-  SinricPro.onDisconnected([](){ Serial.printf("Disconnected from SinricPro\r\n"); });
+  SinricPro.onConnected([](){ SINRICPRO_PRINTF("Connected to SinricPro\r\n"); }); 
+  SinricPro.onDisconnected([](){ SINRICPRO_PRINTF("Disconnected from SinricPro\r\n"); });
   SinricPro.begin(APP_KEY, APP_SECRET);
 }
 
 // main setup function
 void setup() {
-  Serial.begin(BAUD_RATE); Serial.printf("\r\n\r\n");
+  Serial.begin(BAUD_RATE); SINRICPRO_PRINTF("\r\n\r\n");
   setupWiFi();
   setupSinricPro();
 }

--- a/examples/Speaker/Speaker.ino
+++ b/examples/Speaker/Speaker.ino
@@ -25,6 +25,13 @@
   #include <ESP8266WiFi.h>
 #elif defined(ESP32) || defined(ARDUINO_ARCH_RP2040)
   #include <WiFi.h>
+#elif defined(ARDUINO_SAMD_MKRWIFI1010) || defined(ARDUINO_SAMD_NANO_33_IOT)
+  #include <WiFiNINA.h>
+#elif defined(ARDUINO_UNOWIFIR4) || defined(ARDUINO_MINIMA)
+  #include <WiFiS3.h>
+  #ifndef SINRICPRO_NOSSL
+    #define SINRICPRO_NOSSL
+  #endif
 #endif
 
 #include "SinricPro.h"

--- a/examples/Switch/MultiSwitch_advance/MultiSwitch_advance.ino
+++ b/examples/Switch/MultiSwitch_advance/MultiSwitch_advance.ino
@@ -35,6 +35,13 @@
   #include <ESP8266WiFi.h>
 #elif defined(ESP32) || defined(ARDUINO_ARCH_RP2040)
   #include <WiFi.h>
+#elif defined(ARDUINO_SAMD_MKRWIFI1010) || defined(ARDUINO_SAMD_NANO_33_IOT)
+  #include <WiFiNINA.h>
+#elif defined(ARDUINO_UNOWIFIR4) || defined(ARDUINO_MINIMA)
+  #include <WiFiS3.h>
+  #ifndef SINRICPRO_NOSSL
+    #define SINRICPRO_NOSSL
+  #endif
 #endif
 
 #include "SinricPro.h"

--- a/examples/Switch/MultiSwitch_advance/MultiSwitch_advance.ino
+++ b/examples/Switch/MultiSwitch_advance/MultiSwitch_advance.ino
@@ -70,7 +70,7 @@
   #define SWITCHPIN_2 D7
   #define SWITCHPIN_3 D6
   #define SWITCHPIN_4 D5
-#elif defined(ESP32) || defined(ARDUINO_ARCH_RP2040)
+#else
   #define LED_BUILTIN 2
 
   #define RELAYPIN_1 16

--- a/examples/Switch/MultiSwitch_advance/MultiSwitch_advance.ino
+++ b/examples/Switch/MultiSwitch_advance/MultiSwitch_advance.ino
@@ -134,7 +134,7 @@ void setupFlipSwitches() {
 
 bool onPowerState(String deviceId, bool &state)
 {
-  Serial.printf("%s: %s\r\n", deviceId.c_str(), state ? "on" : "off");
+  SINRICPRO_PRINTF("%s: %s\r\n", deviceId.c_str(), state ? "on" : "off");
   int relayPIN = devices[deviceId].relayPIN; // get the relay pin for corresponding device
   digitalWrite(relayPIN, state);             // set the new relay state
   return true;
@@ -163,7 +163,7 @@ void handleFlipSwitches() {
           SinricProSwitch &mySwitch = SinricPro[deviceId];                        // get Switch device from SinricPro
           bool success = mySwitch.sendPowerStateEvent(newRelayState);             // send the event
           if(!success) {
-            Serial.printf("Something went wrong...could not send Event to server!\r\n");
+            SINRICPRO_PRINTF("Something went wrong...could not send Event to server!\r\n");
           }
 
 #ifdef TACTILE_BUTTON
@@ -177,7 +177,7 @@ void handleFlipSwitches() {
 
 void setupWiFi()
 {
-  Serial.printf("\r\n[Wifi]: Connecting");
+  SINRICPRO_PRINTF("\r\n[Wifi]: Connecting");
   
   #if defined(ESP8266)
     WiFi.setSleepMode(WIFI_NONE_SLEEP); 
@@ -191,11 +191,11 @@ void setupWiFi()
 
   while (WiFi.status() != WL_CONNECTED)
   {
-    Serial.printf(".");
+    SINRICPRO_PRINTF(".");
     delay(250);
   }
   digitalWrite(LED_BUILTIN, HIGH);
-  Serial.printf("connected!\r\n[WiFi]: IP-Address is %s\r\n", WiFi.localIP().toString().c_str());
+  SINRICPRO_PRINTF("connected!\r\n[WiFi]: IP-Address is %s\r\n", WiFi.localIP().toString().c_str());
 }
 
 void setupSinricPro()

--- a/examples/Switch/MultiSwitch_beginner/MultiSwitch_beginner.ino
+++ b/examples/Switch/MultiSwitch_beginner/MultiSwitch_beginner.ino
@@ -27,6 +27,13 @@
   #include <ESP8266WiFi.h>
 #elif defined(ESP32) || defined(ARDUINO_ARCH_RP2040)
   #include <WiFi.h>
+#elif defined(ARDUINO_SAMD_MKRWIFI1010) || defined(ARDUINO_SAMD_NANO_33_IOT)
+  #include <WiFiNINA.h>
+#elif defined(ARDUINO_UNOWIFIR4) || defined(ARDUINO_MINIMA)
+  #include <WiFiS3.h>
+  #ifndef SINRICPRO_NOSSL
+    #define SINRICPRO_NOSSL
+  #endif
 #endif
 
 #include "SinricPro.h"

--- a/examples/Switch/MultiSwitch_beginner/MultiSwitch_beginner.ino
+++ b/examples/Switch/MultiSwitch_beginner/MultiSwitch_beginner.ino
@@ -52,29 +52,29 @@
 #define BAUD_RATE         115200                // Change baudrate to your need
 
 bool onPowerState1(const String &deviceId, bool &state) {
-  Serial.printf("Device 1 turned %s\r\n", state?"on":"off");
+  SINRICPRO_PRINTF("Device 1 turned %s\r\n", state?"on":"off");
   return true; // request handled properly
 }
 
 bool onPowerState2(const String &deviceId, bool &state) {
-  Serial.printf("Device 2 turned %s\r\n", state?"on":"off");
+  SINRICPRO_PRINTF("Device 2 turned %s\r\n", state?"on":"off");
   return true; // request handled properly
 }
 
 bool onPowerState3(const String &deviceId, bool &state) {
-  Serial.printf("Device 3 turned %s\r\n", state?"on":"off");
+  SINRICPRO_PRINTF("Device 3 turned %s\r\n", state?"on":"off");
   return true; // request handled properly
 }
 
 bool onPowerState4(const String &deviceId, bool &state) {
-  Serial.printf("Device 4 turned %s\r\n", state?"on":"off");
+  SINRICPRO_PRINTF("Device 4 turned %s\r\n", state?"on":"off");
   return true; // request handled properly
 }
 
 
 // setup function for WiFi connection
 void setupWiFi() {
-  Serial.printf("\r\n[Wifi]: Connecting");
+  SINRICPRO_PRINTF("\r\n[Wifi]: Connecting");
 
   #if defined(ESP8266)
     WiFi.setSleepMode(WIFI_NONE_SLEEP); 
@@ -87,11 +87,11 @@ void setupWiFi() {
   WiFi.begin(WIFI_SSID, WIFI_PASS); 
 
   while (WiFi.status() != WL_CONNECTED) {
-    Serial.printf(".");
+    SINRICPRO_PRINTF(".");
     delay(250);
   }
 
-  Serial.printf("connected!\r\n[WiFi]: IP-Address is %s\r\n", WiFi.localIP().toString().c_str());
+  SINRICPRO_PRINTF("connected!\r\n[WiFi]: IP-Address is %s\r\n", WiFi.localIP().toString().c_str());
 }
 
 // setup function for SinricPro
@@ -110,14 +110,14 @@ void setupSinricPro() {
   mySwitch4.onPowerState(onPowerState4);
 
   // setup SinricPro
-  SinricPro.onConnected([](){ Serial.printf("Connected to SinricPro\r\n"); }); 
-  SinricPro.onDisconnected([](){ Serial.printf("Disconnected from SinricPro\r\n"); });
+  SinricPro.onConnected([](){ SINRICPRO_PRINTF("Connected to SinricPro\r\n"); }); 
+  SinricPro.onDisconnected([](){ SINRICPRO_PRINTF("Disconnected from SinricPro\r\n"); });
   SinricPro.begin(APP_KEY, APP_SECRET);
 }
 
 // main setup function
 void setup() {
-  Serial.begin(BAUD_RATE); Serial.printf("\r\n\r\n");
+  Serial.begin(BAUD_RATE); SINRICPRO_PRINTF("\r\n\r\n");
   setupWiFi();
   setupSinricPro();
 }

--- a/examples/Switch/MultiSwitch_intermediate/MultiSwitch_intermediate.ino
+++ b/examples/Switch/MultiSwitch_intermediate/MultiSwitch_intermediate.ino
@@ -56,7 +56,7 @@ String SWITCH_IDs[DEVICES] = {                // define deviceIds in an array
 bool onPowerState(const String &deviceId, bool &state) {
   for (int i=0; i < DEVICES; i++) {     // go through the devices
     if (deviceId == SWITCH_IDs[i]) {    // if deviceId matches
-      Serial.printf("Device number %i turned %s\r\n", i, state?"on":"off");   // print power state for device
+      SINRICPRO_PRINTF("Device number %i turned %s\r\n", i, state?"on":"off");   // print power state for device
     }
   }
   return true; // request handled properly
@@ -64,7 +64,7 @@ bool onPowerState(const String &deviceId, bool &state) {
 
 // setup function for WiFi connection
 void setupWiFi() {
-  Serial.printf("\r\n[Wifi]: Connecting");
+  SINRICPRO_PRINTF("\r\n[Wifi]: Connecting");
 
   #if defined(ESP8266)
     WiFi.setSleepMode(WIFI_NONE_SLEEP); 
@@ -77,11 +77,11 @@ void setupWiFi() {
   WiFi.begin(WIFI_SSID, WIFI_PASS); 
 
   while (WiFi.status() != WL_CONNECTED) {
-    Serial.printf(".");
+    SINRICPRO_PRINTF(".");
     delay(250);
   }
 
-  Serial.printf("connected!\r\n[WiFi]: IP-Address is %s\r\n", WiFi.localIP().toString().c_str());
+  SINRICPRO_PRINTF("connected!\r\n[WiFi]: IP-Address is %s\r\n", WiFi.localIP().toString().c_str());
 }
 
 // setup function for SinricPro
@@ -93,14 +93,14 @@ void setupSinricPro() {
   }
 
   // setup SinricPro
-  SinricPro.onConnected([](){ Serial.printf("Connected to SinricPro\r\n"); }); 
-  SinricPro.onDisconnected([](){ Serial.printf("Disconnected from SinricPro\r\n"); });
+  SinricPro.onConnected([](){ SINRICPRO_PRINTF("Connected to SinricPro\r\n"); }); 
+  SinricPro.onDisconnected([](){ SINRICPRO_PRINTF("Disconnected from SinricPro\r\n"); });
   SinricPro.begin(APP_KEY, APP_SECRET);
 }
 
 // main setup function
 void setup() {
-  Serial.begin(BAUD_RATE); Serial.printf("\r\n\r\n");
+  Serial.begin(BAUD_RATE); SINRICPRO_PRINTF("\r\n\r\n");
   setupWiFi();
   setupSinricPro();
 }

--- a/examples/Switch/MultiSwitch_intermediate/MultiSwitch_intermediate.ino
+++ b/examples/Switch/MultiSwitch_intermediate/MultiSwitch_intermediate.ino
@@ -27,6 +27,13 @@
   #include <ESP8266WiFi.h>
 #elif defined(ESP32) || defined(ARDUINO_ARCH_RP2040)
   #include <WiFi.h>
+#elif defined(ARDUINO_SAMD_MKRWIFI1010) || defined(ARDUINO_SAMD_NANO_33_IOT)
+  #include <WiFiNINA.h>
+#elif defined(ARDUINO_UNOWIFIR4) || defined(ARDUINO_MINIMA)
+  #include <WiFiS3.h>
+  #ifndef SINRICPRO_NOSSL
+    #define SINRICPRO_NOSSL
+  #endif
 #endif
 
 #include "SinricPro.h"

--- a/examples/Switch/Switch/Switch.ino
+++ b/examples/Switch/Switch/Switch.ino
@@ -67,7 +67,7 @@ unsigned long lastBtnPress = 0;
  *  true if request should be marked as handled correctly / false if not
  */
 bool onPowerState(const String &deviceId, bool &state) {
-  Serial.printf("Device %s turned %s (via SinricPro) \r\n", deviceId.c_str(), state?"on":"off");
+  SINRICPRO_PRINTF("Device %s turned %s (via SinricPro) \r\n", deviceId.c_str(), state?"on":"off");
   myPowerState = state;
   digitalWrite(LED_PIN, myPowerState?LOW:HIGH);
   return true; // request handled properly
@@ -88,34 +88,34 @@ void handleButtonPress() {
     // send powerstate event
     bool success = mySwitch.sendPowerStateEvent(myPowerState); // send the new powerState to SinricPro server
     if(!success) {
-      Serial.printf("Something went wrong...could not send Event to server!\r\n");
+      SINRICPRO_PRINTF("Something went wrong...could not send Event to server!\r\n");
     }
 
-    Serial.printf("Device %s turned %s (manually via flashbutton)\r\n", mySwitch.getDeviceId().c_str(), myPowerState?"on":"off");
+    SINRICPRO_PRINTF("Device %s turned %s (manually via flashbutton)\r\n", mySwitch.getDeviceId().c_str(), myPowerState?"on":"off");
 
     lastBtnPress = actualMillis;  // update last button press variable
-  } 
+  }
 }
 
 // setup function for WiFi connection
 void setupWiFi() {
-  Serial.printf("\r\n[Wifi]: Connecting");
+  SINRICPRO_PRINTF("\r\n[Wifi]: Connecting");
 
   #if defined(ESP8266)
-    WiFi.setSleepMode(WIFI_NONE_SLEEP); 
+    WiFi.setSleepMode(WIFI_NONE_SLEEP);
     WiFi.setAutoReconnect(true);
   #elif defined(ESP32)
-    WiFi.setSleep(false); 
+    WiFi.setSleep(false);
     WiFi.setAutoReconnect(true);
   #endif
 
-  WiFi.begin(WIFI_SSID, WIFI_PASS); 
+  WiFi.begin(WIFI_SSID, WIFI_PASS);
 
   while (WiFi.status() != WL_CONNECTED) {
-    Serial.printf(".");
+    SINRICPRO_PRINTF(".");
     delay(250);
   }
-  Serial.printf("connected!\r\n[WiFi]: IP-Address is %s\r\n", WiFi.localIP().toString().c_str());
+  SINRICPRO_PRINTF("connected!\r\n[WiFi]: IP-Address is %s\r\n", WiFi.localIP().toString().c_str());
 }
 
 // setup function for SinricPro
@@ -127,8 +127,8 @@ void setupSinricPro() {
   mySwitch.onPowerState(onPowerState);
 
   // setup SinricPro
-  SinricPro.onConnected([](){ Serial.printf("Connected to SinricPro\r\n"); }); 
-  SinricPro.onDisconnected([](){ Serial.printf("Disconnected from SinricPro\r\n"); });
+  SinricPro.onConnected([](){ SINRICPRO_PRINTF("Connected to SinricPro\r\n"); });
+  SinricPro.onDisconnected([](){ SINRICPRO_PRINTF("Disconnected from SinricPro\r\n"); });
   //SinricPro.restoreDeviceStates(true); // Uncomment to restore the last known state from the server.
   SinricPro.begin(APP_KEY, APP_SECRET);
 }
@@ -139,7 +139,7 @@ void setup() {
   pinMode(LED_PIN, OUTPUT); // define LED GPIO as output
   digitalWrite(LED_PIN, HIGH); // turn off LED on bootup
 
-  Serial.begin(BAUD_RATE); Serial.printf("\r\n\r\n");
+  Serial.begin(BAUD_RATE); SINRICPRO_PRINTF("\r\n\r\n");
   setupWiFi();
   setupSinricPro();
 }

--- a/examples/Switch/Switch/Switch.ino
+++ b/examples/Switch/Switch/Switch.ino
@@ -28,6 +28,13 @@
   #include <ESP8266WiFi.h>
 #elif defined(ESP32) || defined(ARDUINO_ARCH_RP2040)
   #include <WiFi.h>
+#elif defined(ARDUINO_SAMD_MKRWIFI1010) || defined(ARDUINO_SAMD_NANO_33_IOT)
+  #include <WiFiNINA.h>
+#elif defined(ARDUINO_UNOWIFIR4) || defined(ARDUINO_MINIMA)
+  #include <WiFiS3.h>
+  #ifndef SINRICPRO_NOSSL
+    #define SINRICPRO_NOSSL
+  #endif
 #endif
 
 #include "SinricPro.h"

--- a/examples/TV/TV.ino
+++ b/examples/TV/TV.ino
@@ -86,14 +86,14 @@ void setupChannelNumbers() {
 
 bool onAdjustVolume(const String &deviceId, int &volumeDelta, bool volumeDefault) {
   tvVolume += volumeDelta;  // calcualte new absolute volume
-  Serial.printf("Volume changed about %i to %i\r\n", volumeDelta, tvVolume);
+  SINRICPRO_PRINTF("Volume changed about %i to %i\r\n", volumeDelta, tvVolume);
   volumeDelta = tvVolume; // return new absolute volume
   return true;
 }
 
 bool onChangeChannel(const String &deviceId, String &channel) {
   tvChannel = channelNumbers[channel]; // save new channelNumber in tvChannel variable
-  Serial.printf("Change channel to \"%s\" (channel number %d)\r\n", channel.c_str(), tvChannel);
+  SINRICPRO_PRINTF("Change channel to \"%s\" (channel number %d)\r\n", channel.c_str(), tvChannel);
   return true;
 }
 
@@ -104,12 +104,12 @@ bool onChangeChannelNumber(const String& deviceId, int channelNumber, String& ch
 
   channelName = channelNames[tvChannel]; // return the channelName
 
-  Serial.printf("Change to channel to %d (channel name \"%s\")\r\n", tvChannel, channelName.c_str());
+  SINRICPRO_PRINTF("Change to channel to %d (channel name \"%s\")\r\n", tvChannel, channelName.c_str());
   return true;
 }
 
 bool onMediaControl(const String &deviceId, String &control) {
-  Serial.printf("MediaControl: %s\r\n", control.c_str());
+  SINRICPRO_PRINTF("MediaControl: %s\r\n", control.c_str());
   if (control == "Play") {}           // do whatever you want to do here
   if (control == "Pause") {}          // do whatever you want to do here
   if (control == "Stop") {}           // do whatever you want to do here
@@ -122,24 +122,24 @@ bool onMediaControl(const String &deviceId, String &control) {
 }
 
 bool onMute(const String &deviceId, bool &mute) {
-  Serial.printf("TV volume is %s\r\n", mute?"muted":"unmuted");
+  SINRICPRO_PRINTF("TV volume is %s\r\n", mute?"muted":"unmuted");
   tvMuted = mute; // set tvMuted state
   return true;
 }
 
 bool onPowerState(const String &deviceId, bool &state) {
-  Serial.printf("TV turned %s\r\n", state?"on":"off");
+  SINRICPRO_PRINTF("TV turned %s\r\n", state?"on":"off");
   tvPowerState = state; // set powerState
   return true; 
 }
 
 bool onSelectInput(const String &deviceId, String &input) {
-  Serial.printf("Input changed to %s\r\n", input.c_str());
+  SINRICPRO_PRINTF("Input changed to %s\r\n", input.c_str());
   return true;
 }
 
 bool onSetVolume(const String &deviceId, int &volume) {
-  Serial.printf("Volume set to:  %i\r\n", volume);
+  SINRICPRO_PRINTF("Volume set to:  %i\r\n", volume);
   tvVolume = volume; // update tvVolume
   return true;
 }
@@ -150,14 +150,14 @@ bool onSkipChannels(const String &deviceId, const int channelCount, String &chan
   if (tvChannel > MAX_CHANNELS-1) tvChannel = MAX_CHANNELS-1;
   channelName = String(channelNames[tvChannel]); // return channel name
 
-  Serial.printf("Skip channel: %i (number: %i / name: \"%s\")\r\n", channelCount, tvChannel, channelName.c_str());
+  SINRICPRO_PRINTF("Skip channel: %i (number: %i / name: \"%s\")\r\n", channelCount, tvChannel, channelName.c_str());
 
   return true;
 }
 
 // setup function for WiFi connection
 void setupWiFi() {
-  Serial.printf("\r\n[Wifi]: Connecting");
+  SINRICPRO_PRINTF("\r\n[Wifi]: Connecting");
 
   #if defined(ESP8266)
     WiFi.setSleepMode(WIFI_NONE_SLEEP); 
@@ -170,11 +170,11 @@ void setupWiFi() {
   WiFi.begin(WIFI_SSID, WIFI_PASS); 
 
   while (WiFi.status() != WL_CONNECTED) {
-    Serial.printf(".");
+    SINRICPRO_PRINTF(".");
     delay(250);
   }
   IPAddress localIP = WiFi.localIP();
-  Serial.printf("connected!\r\n[WiFi]: IP-Address is %d.%d.%d.%d\r\n", localIP[0], localIP[1], localIP[2], localIP[3]);
+  SINRICPRO_PRINTF("connected!\r\n[WiFi]: IP-Address is %d.%d.%d.%d\r\n", localIP[0], localIP[1], localIP[2], localIP[3]);
 }
 
 // setup function for SinricPro
@@ -194,15 +194,15 @@ void setupSinricPro() {
   myTV.onSkipChannels(onSkipChannels);
 
   // setup SinricPro
-  SinricPro.onConnected([](){ Serial.printf("Connected to SinricPro\r\n"); }); 
-  SinricPro.onDisconnected([](){ Serial.printf("Disconnected from SinricPro\r\n"); });
+  SinricPro.onConnected([](){ SINRICPRO_PRINTF("Connected to SinricPro\r\n"); }); 
+  SinricPro.onDisconnected([](){ SINRICPRO_PRINTF("Disconnected from SinricPro\r\n"); });
   SinricPro.begin(APP_KEY, APP_SECRET);
 }
 
 // main setup function
 void setup() {
-  Serial.begin(BAUD_RATE); Serial.printf("\r\n\r\n");
-  Serial.printf("%d channels configured\r\n", MAX_CHANNELS);
+  Serial.begin(BAUD_RATE); SINRICPRO_PRINTF("\r\n\r\n");
+  SINRICPRO_PRINTF("%d channels configured\r\n", MAX_CHANNELS);
 
   setupWiFi();
   setupSinricPro();

--- a/examples/TV/TV.ino
+++ b/examples/TV/TV.ino
@@ -27,6 +27,13 @@
   #include <ESP8266WiFi.h>
 #elif defined(ESP32) || defined(ARDUINO_ARCH_RP2040)
   #include <WiFi.h>
+#elif defined(ARDUINO_SAMD_MKRWIFI1010) || defined(ARDUINO_SAMD_NANO_33_IOT)
+  #include <WiFiNINA.h>
+#elif defined(ARDUINO_UNOWIFIR4) || defined(ARDUINO_MINIMA)
+  #include <WiFiS3.h>
+  #ifndef SINRICPRO_NOSSL
+    #define SINRICPRO_NOSSL
+  #endif
 #endif
 
 #include "SinricPro.h"

--- a/examples/Thermostat/Thermostat.ino
+++ b/examples/Thermostat/Thermostat.ino
@@ -48,32 +48,32 @@ float globalTemperature;
 bool globalPowerState;
 
 bool onPowerState(const String &deviceId, bool &state) {
-  Serial.printf("Thermostat %s turned %s\r\n", deviceId.c_str(), state?"on":"off");
+  SINRICPRO_PRINTF("Thermostat %s turned %s\r\n", deviceId.c_str(), state?"on":"off");
   globalPowerState = state; 
   return true; // request handled properly
 }
 
 bool onTargetTemperature(const String &deviceId, float &temperature) {
-  Serial.printf("Thermostat %s set temperature to %f\r\n", deviceId.c_str(), temperature);
+  SINRICPRO_PRINTF("Thermostat %s set temperature to %f\r\n", deviceId.c_str(), temperature);
   globalTemperature = temperature;
   return true;
 }
 
 bool onAdjustTargetTemperature(const String & deviceId, float &temperatureDelta) {
   globalTemperature += temperatureDelta;  // calculate absolut temperature
-  Serial.printf("Thermostat %s changed temperature about %f to %f", deviceId.c_str(), temperatureDelta, globalTemperature);
+  SINRICPRO_PRINTF("Thermostat %s changed temperature about %f to %f", deviceId.c_str(), temperatureDelta, globalTemperature);
   temperatureDelta = globalTemperature; // return absolut temperature
   return true;
 }
 
 bool onThermostatMode(const String &deviceId, String &mode) {
-  Serial.printf("Thermostat %s set to mode %s\r\n", deviceId.c_str(), mode.c_str());
+  SINRICPRO_PRINTF("Thermostat %s set to mode %s\r\n", deviceId.c_str(), mode.c_str());
   return true;
 }
 
 
 void setupWiFi() {
-  Serial.printf("\r\n[Wifi]: Connecting");
+  SINRICPRO_PRINTF("\r\n[Wifi]: Connecting");
 
   #if defined(ESP8266)
     WiFi.setSleepMode(WIFI_NONE_SLEEP); 
@@ -86,11 +86,11 @@ void setupWiFi() {
   WiFi.begin(WIFI_SSID, WIFI_PASS); 
 
   while (WiFi.status() != WL_CONNECTED) {
-    Serial.printf(".");
+    SINRICPRO_PRINTF(".");
     delay(250);
   }
   IPAddress localIP = WiFi.localIP();
-  Serial.printf("connected!\r\n[WiFi]: IP-Address is %d.%d.%d.%d\r\n", localIP[0], localIP[1], localIP[2], localIP[3]);
+  SINRICPRO_PRINTF("connected!\r\n[WiFi]: IP-Address is %d.%d.%d.%d\r\n", localIP[0], localIP[1], localIP[2], localIP[3]);
 }
 
 void setupSinricPro() {
@@ -101,13 +101,13 @@ void setupSinricPro() {
   myThermostat.onThermostatMode(onThermostatMode);
 
   // setup SinricPro
-  SinricPro.onConnected([](){ Serial.printf("Connected to SinricPro\r\n"); }); 
-  SinricPro.onDisconnected([](){ Serial.printf("Disconnected from SinricPro\r\n"); });
+  SinricPro.onConnected([](){ SINRICPRO_PRINTF("Connected to SinricPro\r\n"); }); 
+  SinricPro.onDisconnected([](){ SINRICPRO_PRINTF("Disconnected from SinricPro\r\n"); });
   SinricPro.begin(APP_KEY, APP_SECRET);
 }
 
 void setup() {
-  Serial.begin(BAUD_RATE); Serial.printf("\r\n\r\n");
+  Serial.begin(BAUD_RATE); SINRICPRO_PRINTF("\r\n\r\n");
   setupWiFi();
   setupSinricPro();
 }

--- a/examples/Thermostat/Thermostat.ino
+++ b/examples/Thermostat/Thermostat.ino
@@ -25,6 +25,13 @@
   #include <ESP8266WiFi.h>
 #elif defined(ESP32) || defined(ARDUINO_ARCH_RP2040)
   #include <WiFi.h>
+#elif defined(ARDUINO_SAMD_MKRWIFI1010) || defined(ARDUINO_SAMD_NANO_33_IOT)
+  #include <WiFiNINA.h>
+#elif defined(ARDUINO_UNOWIFIR4) || defined(ARDUINO_MINIMA)
+  #include <WiFiS3.h>
+  #ifndef SINRICPRO_NOSSL
+    #define SINRICPRO_NOSSL
+  #endif
 #endif
 
 #include "SinricPro.h"

--- a/examples/doorbell/doorbell.ino
+++ b/examples/doorbell/doorbell.ino
@@ -27,6 +27,13 @@
   #include <ESP8266WiFi.h>
 #elif defined(ESP32) || defined(ARDUINO_ARCH_RP2040)
   #include <WiFi.h>
+#elif defined(ARDUINO_SAMD_MKRWIFI1010) || defined(ARDUINO_SAMD_NANO_33_IOT)
+  #include <WiFiNINA.h>
+#elif defined(ARDUINO_UNOWIFIR4) || defined(ARDUINO_MINIMA)
+  #include <WiFiS3.h>
+  #ifndef SINRICPRO_NOSSL
+    #define SINRICPRO_NOSSL
+  #endif
 #endif
 
 #include "SinricPro.h"

--- a/examples/doorbell/doorbell.ino
+++ b/examples/doorbell/doorbell.ino
@@ -60,7 +60,7 @@ void checkButtonPress() {
 
   if (actualMillis-lastBtnPress > 500) {
     if (digitalRead(BUTTON_PIN)==LOW) {
-      Serial.printf("Ding dong...\r\n");
+      SINRICPRO_PRINTF("Ding dong...\r\n");
       lastBtnPress = actualMillis;
 
       // get Doorbell device back
@@ -69,7 +69,7 @@ void checkButtonPress() {
       // send doorbell event
       bool success = myDoorbell.sendDoorbellEvent();
       if(!success) {
-        Serial.printf("Something went wrong...could not send Event to server!\r\n");
+        SINRICPRO_PRINTF("Something went wrong...could not send Event to server!\r\n");
       }
     }
   }
@@ -77,7 +77,7 @@ void checkButtonPress() {
 
 // setup function for WiFi connection
 void setupWiFi() {
-  Serial.printf("\r\n[Wifi]: Connecting");
+  SINRICPRO_PRINTF("\r\n[Wifi]: Connecting");
 
   #if defined(ESP8266)
     WiFi.setSleepMode(WIFI_NONE_SLEEP); 
@@ -90,11 +90,11 @@ void setupWiFi() {
   WiFi.begin(WIFI_SSID, WIFI_PASS);
 
   while (WiFi.status() != WL_CONNECTED) {
-    Serial.printf(".");
+    SINRICPRO_PRINTF(".");
     delay(250);
   }
   IPAddress localIP = WiFi.localIP();
-  Serial.printf("connected!\r\n[WiFi]: IP-Address is %d.%d.%d.%d\r\n", localIP[0], localIP[1], localIP[2], localIP[3]);
+  SINRICPRO_PRINTF("connected!\r\n[WiFi]: IP-Address is %d.%d.%d.%d\r\n", localIP[0], localIP[1], localIP[2], localIP[3]);
 }
 
 // setup function for SinricPro
@@ -102,8 +102,8 @@ void setupSinricPro() {
   // add doorbell device to SinricPro
   SinricProDoorbell& myDoorbell = SinricPro[DOORBELL_ID];
   // setup SinricPro
-  SinricPro.onConnected([](){ Serial.printf("Connected to SinricPro\r\n"); }); 
-  SinricPro.onDisconnected([](){ Serial.printf("Disconnected from SinricPro\r\n"); });
+  SinricPro.onConnected([](){ SINRICPRO_PRINTF("Connected to SinricPro\r\n"); }); 
+  SinricPro.onDisconnected([](){ SINRICPRO_PRINTF("Disconnected from SinricPro\r\n"); });
   SinricPro.begin(APP_KEY, APP_SECRET);
 }
 
@@ -111,7 +111,7 @@ void setupSinricPro() {
 void setup() {
   pinMode(BUTTON_PIN, INPUT_PULLUP); // BUTTIN_PIN as INPUT
 
-  Serial.begin(BAUD_RATE); Serial.printf("\r\n\r\n");
+  Serial.begin(BAUD_RATE); SINRICPRO_PRINTF("\r\n\r\n");
   setupWiFi();
   setupSinricPro();
 }

--- a/examples/platformio/platformio.ini
+++ b/examples/platformio/platformio.ini
@@ -37,3 +37,26 @@ board = esp32dev
 platform = https://github.com/maxgerhardt/platform-raspberrypi.git
 board = pico
 board_build.core = earlephilhower
+
+[env:nano_33_iot]
+platform = atmelsam
+board = nano_33_iot
+framework = arduino
+lib_deps =
+  sinricpro/SinricPro
+  arduino-libraries/WiFiNINA
+
+[env:mkrwifi1010]
+platform = atmelsam
+board = mkrwifi1010
+framework = arduino
+lib_deps =
+  sinricpro/SinricPro
+  arduino-libraries/WiFiNINA
+
+[env:uno_r4_wifi]
+platform = renesas-ra
+board = uno_r4_wifi
+framework = arduino
+lib_deps = sinricpro/SinricPro
+build_flags = -D SINRICPRO_NOSSL

--- a/examples/temperaturesensor/AHT10/AHT10.ino
+++ b/examples/temperaturesensor/AHT10/AHT10.ino
@@ -35,6 +35,13 @@
   #include <ESP8266WiFi.h>
 #elif defined(ESP32) || defined(ARDUINO_ARCH_RP2040)
   #include <WiFi.h>
+#elif defined(ARDUINO_SAMD_MKRWIFI1010) || defined(ARDUINO_SAMD_NANO_33_IOT)
+  #include <WiFiNINA.h>
+#elif defined(ARDUINO_UNOWIFIR4) || defined(ARDUINO_MINIMA)
+  #include <WiFiS3.h>
+  #ifndef SINRICPRO_NOSSL
+    #define SINRICPRO_NOSSL
+  #endif
 #endif
 
 #include "SinricPro.h"

--- a/examples/temperaturesensor/AHT10/AHT10.ino
+++ b/examples/temperaturesensor/AHT10/AHT10.ino
@@ -74,7 +74,7 @@ void handleTemperaturesensor() {
   unsigned long actualMillis = millis();
   if (actualMillis - lastEvent < EVENT_WAIT_TIME) return; //only check every EVENT_WAIT_TIME milliseconds
   if (!aht.begin()) {
-    Serial.printf("Sensor not initialized\r\n");
+    SINRICPRO_PRINTF("Sensor not initialized\r\n");
     return;
   }
 
@@ -84,7 +84,7 @@ void handleTemperaturesensor() {
   float temperature = temp.temperature; 
 
   if (isnan(temperature) || isnan(humidity)) { // reading failed... 
-    Serial.printf("AHT reading failed!\r\n");  // print error message
+    SINRICPRO_PRINTF("AHT reading failed!\r\n");  // print error message
     return;                                    // try again next time
   }
 
@@ -93,9 +93,9 @@ void handleTemperaturesensor() {
   SinricProTemperaturesensor &mySensor = SinricPro[TEMP_SENSOR_ID];  // get temperaturesensor device
   bool success = mySensor.sendTemperatureEvent(temperature, humidity); // send event
   if (success) {  // if event was sent successfuly, print temperature and humidity to serial
-    Serial.printf("Temperature: %2.1f Celsius\tHumidity: %2.1f%%\r\n", temperature, humidity);
+    SINRICPRO_PRINTF("Temperature: %2.1f Celsius\tHumidity: %2.1f%%\r\n", temperature, humidity);
   } else {  // if sending event failed, print error message
-    Serial.printf("Something went wrong...could not send Event to server!\r\n");
+    SINRICPRO_PRINTF("Something went wrong...could not send Event to server!\r\n");
   }
 
   lastTemperature = temperature;  // save actual temperature for next compare
@@ -106,7 +106,7 @@ void handleTemperaturesensor() {
 
 // setup function for WiFi connection
 void setupWiFi() {
-  Serial.printf("\r\n[Wifi]: Connecting");
+  SINRICPRO_PRINTF("\r\n[Wifi]: Connecting");
 
   #if defined(ESP8266)
     WiFi.setSleepMode(WIFI_NONE_SLEEP); 
@@ -119,11 +119,11 @@ void setupWiFi() {
   WiFi.begin(WIFI_SSID, WIFI_PASS); 
 
   while (WiFi.status() != WL_CONNECTED) {
-    Serial.printf(".");
+    SINRICPRO_PRINTF(".");
     delay(250);
   }
   IPAddress localIP = WiFi.localIP();
-  Serial.printf("connected!\r\n[WiFi]: IP-Address is %d.%d.%d.%d\r\n", localIP[0], localIP[1], localIP[2], localIP[3]);
+  SINRICPRO_PRINTF("connected!\r\n[WiFi]: IP-Address is %d.%d.%d.%d\r\n", localIP[0], localIP[1], localIP[2], localIP[3]);
 }
 
 // setup function for SinricPro
@@ -132,15 +132,15 @@ void setupSinricPro() {
   SinricProTemperaturesensor &mySensor = SinricPro[TEMP_SENSOR_ID];
   
   // setup SinricPro
-  SinricPro.onConnected([](){ Serial.printf("Connected to SinricPro\r\n"); }); 
-  SinricPro.onDisconnected([](){ Serial.printf("Disconnected from SinricPro\r\n"); });
+  SinricPro.onConnected([](){ SINRICPRO_PRINTF("Connected to SinricPro\r\n"); }); 
+  SinricPro.onDisconnected([](){ SINRICPRO_PRINTF("Disconnected from SinricPro\r\n"); });
   //SinricPro.restoreDeviceStates(true); // Uncomment to restore the last known state from the server.
   SinricPro.begin(APP_KEY, APP_SECRET);
 }
 
 // main setup function
 void setup() {
-  Serial.begin(BAUD_RATE); Serial.printf("\r\n\r\n");
+  Serial.begin(BAUD_RATE); SINRICPRO_PRINTF("\r\n\r\n");
   aht.begin();
   setupWiFi();
   setupSinricPro();

--- a/examples/temperaturesensor/DHT22/DHT22.ino
+++ b/examples/temperaturesensor/DHT22/DHT22.ino
@@ -31,6 +31,13 @@
   #include <ESP8266WiFi.h>
 #elif defined(ESP32) || defined(ARDUINO_ARCH_RP2040)
   #include <WiFi.h>
+#elif defined(ARDUINO_SAMD_MKRWIFI1010) || defined(ARDUINO_SAMD_NANO_33_IOT)
+  #include <WiFiNINA.h>
+#elif defined(ARDUINO_UNOWIFIR4) || defined(ARDUINO_MINIMA)
+  #include <WiFiS3.h>
+  #ifndef SINRICPRO_NOSSL
+    #define SINRICPRO_NOSSL
+  #endif
 #endif
 
 #include "SinricPro.h"

--- a/examples/temperaturesensor/DHT22/DHT22.ino
+++ b/examples/temperaturesensor/DHT22/DHT22.ino
@@ -82,7 +82,7 @@ void handleTemperaturesensor() {
   humidity = dht.getHumidity();                // get actual humidity
 
   if (isnan(temperature) || isnan(humidity)) { // reading failed... 
-    Serial.printf("DHT reading failed!\r\n");  // print error message
+    SINRICPRO_PRINTF("DHT reading failed!\r\n");  // print error message
     return;                                    // try again next time
   } 
 
@@ -91,9 +91,9 @@ void handleTemperaturesensor() {
   SinricProTemperaturesensor &mySensor = SinricPro[TEMP_SENSOR_ID];  // get temperaturesensor device
   bool success = mySensor.sendTemperatureEvent(temperature, humidity); // send event
   if (success) {  // if event was sent successfuly, print temperature and humidity to serial
-    Serial.printf("Temperature: %2.1f Celsius\tHumidity: %2.1f%%\r\n", temperature, humidity);
+    SINRICPRO_PRINTF("Temperature: %2.1f Celsius\tHumidity: %2.1f%%\r\n", temperature, humidity);
   } else {  // if sending event failed, print error message
-    Serial.printf("Something went wrong...could not send Event to server!\r\n");
+    SINRICPRO_PRINTF("Something went wrong...could not send Event to server!\r\n");
   }
 
   lastTemperature = temperature;  // save actual temperature for next compare
@@ -104,7 +104,7 @@ void handleTemperaturesensor() {
 
 // setup function for WiFi connection
 void setupWiFi() {
-  Serial.printf("\r\n[Wifi]: Connecting");
+  SINRICPRO_PRINTF("\r\n[Wifi]: Connecting");
 
   #if defined(ESP8266)
     WiFi.setSleepMode(WIFI_NONE_SLEEP); 
@@ -117,11 +117,11 @@ void setupWiFi() {
   WiFi.begin(WIFI_SSID, WIFI_PASS); 
 
   while (WiFi.status() != WL_CONNECTED) {
-    Serial.printf(".");
+    SINRICPRO_PRINTF(".");
     delay(250);
   }
   IPAddress localIP = WiFi.localIP();
-  Serial.printf("connected!\r\n[WiFi]: IP-Address is %d.%d.%d.%d\r\n", localIP[0], localIP[1], localIP[2], localIP[3]);
+  SINRICPRO_PRINTF("connected!\r\n[WiFi]: IP-Address is %d.%d.%d.%d\r\n", localIP[0], localIP[1], localIP[2], localIP[3]);
 }
 
 // setup function for SinricPro
@@ -130,15 +130,15 @@ void setupSinricPro() {
   SinricProTemperaturesensor &mySensor = SinricPro[TEMP_SENSOR_ID];
 
   // setup SinricPro
-  SinricPro.onConnected([](){ Serial.printf("Connected to SinricPro\r\n"); }); 
-  SinricPro.onDisconnected([](){ Serial.printf("Disconnected from SinricPro\r\n"); });
+  SinricPro.onConnected([](){ SINRICPRO_PRINTF("Connected to SinricPro\r\n"); }); 
+  SinricPro.onDisconnected([](){ SINRICPRO_PRINTF("Disconnected from SinricPro\r\n"); });
   //SinricPro.restoreDeviceStates(true); // Uncomment to restore the last known state from the server.
   SinricPro.begin(APP_KEY, APP_SECRET);  
 }
 
 // main setup function
 void setup() {
-  Serial.begin(BAUD_RATE); Serial.printf("\r\n\r\n");
+  Serial.begin(BAUD_RATE); SINRICPRO_PRINTF("\r\n\r\n");
   dht.setup(DHT_PIN);
 
   setupWiFi();

--- a/examples/temperaturesensor/DHT22/DHT22.ino
+++ b/examples/temperaturesensor/DHT22/DHT22.ino
@@ -54,7 +54,7 @@
 
 #if defined(ESP8266)
        #define DHT_PIN    D5
-#elif defined(ESP32) || defined(ARDUINO_ARCH_RP2040)
+#else
        #define DHT_PIN    5
 #endif
 

--- a/examples/temperaturesensor/HTU21D/HTU21D.ino
+++ b/examples/temperaturesensor/HTU21D/HTU21D.ino
@@ -37,7 +37,7 @@
   #ifndef SINRICPRO_NOSSL
     #define SINRICPRO_NOSSL
   #endif
-#endiff
+#endif
 
 #include "SinricPro.h"
 #include "SinricProTemperaturesensor.h"
@@ -58,7 +58,7 @@ Adafruit_HTU21DF htu = Adafruit_HTU21DF();
 #if defined(ESP8266)
   #define I2C_SCL 14    //D5                
   #define I2C_SDA 12    //D6
-#elif defined(ESP32) || defined(ARDUINO_ARCH_RP2040)
+#else
   #define I2C_SCL 18                    
   #define I2C_SDA 19 
 #endif

--- a/examples/temperaturesensor/HTU21D/HTU21D.ino
+++ b/examples/temperaturesensor/HTU21D/HTU21D.ino
@@ -81,7 +81,7 @@ void handleTemperaturesensor() {
   if (actualMillis - lastEvent < EVENT_WAIT_TIME) return; //only check every EVENT_WAIT_TIME milliseconds
 
   if (!htu.begin()) {
-    Serial.printf("Sensor not initialized\r\n");
+    SINRICPRO_PRINTF("Sensor not initialized\r\n");
     return;
   }
 
@@ -89,7 +89,7 @@ void handleTemperaturesensor() {
   float humidity = htu.readHumidity();
 
   if (isnan(temperature) || isnan(humidity)) { // reading failed... 
-    Serial.printf("htu reading failed!\r\n");  // print error message
+    SINRICPRO_PRINTF("htu reading failed!\r\n");  // print error message
     return;                                    // try again next time
   } 
 
@@ -98,9 +98,9 @@ void handleTemperaturesensor() {
   SinricProTemperaturesensor &mySensor = SinricPro[TEMP_SENSOR_ID];  // get temperaturesensor device
   bool success = mySensor.sendTemperatureEvent(temperature, humidity); // send event
   if (success) {  // if event was sent successfuly, print temperature and humidity to serial
-    Serial.printf("Temperature: %2.1f Celsius\tHumidity: %2.1f%%\r\n", temperature, humidity);
+    SINRICPRO_PRINTF("Temperature: %2.1f Celsius\tHumidity: %2.1f%%\r\n", temperature, humidity);
   } else {  // if sending event failed, print error message
-    Serial.printf("Something went wrong...could not send Event to server!\r\n");
+    SINRICPRO_PRINTF("Something went wrong...could not send Event to server!\r\n");
   }
 
   lastTemperature = temperature;  // save actual temperature for next compare
@@ -111,7 +111,7 @@ void handleTemperaturesensor() {
 
 // setup function for WiFi connection
 void setupWiFi() {
-  Serial.printf("\r\n[Wifi]: Connecting");
+  SINRICPRO_PRINTF("\r\n[Wifi]: Connecting");
   
   #if defined(ESP8266)
     WiFi.setSleepMode(WIFI_NONE_SLEEP); 
@@ -124,11 +124,11 @@ void setupWiFi() {
   WiFi.begin(WIFI_SSID, WIFI_PASS); 
 
   while (WiFi.status() != WL_CONNECTED) {
-    Serial.printf(".");
+    SINRICPRO_PRINTF(".");
     delay(250);
   }
   IPAddress localIP = WiFi.localIP();
-  Serial.printf("connected!\r\n[WiFi]: IP-Address is %d.%d.%d.%d\r\n", localIP[0], localIP[1], localIP[2], localIP[3]);
+  SINRICPRO_PRINTF("connected!\r\n[WiFi]: IP-Address is %d.%d.%d.%d\r\n", localIP[0], localIP[1], localIP[2], localIP[3]);
 }
 
 // setup function for SinricPro
@@ -137,15 +137,15 @@ void setupSinricPro() {
   SinricProTemperaturesensor &mySensor = SinricPro[TEMP_SENSOR_ID];
 
   // setup SinricPro
-  SinricPro.onConnected([](){ Serial.printf("Connected to SinricPro\r\n"); }); 
-  SinricPro.onDisconnected([](){ Serial.printf("Disconnected from SinricPro\r\n"); });
+  SinricPro.onConnected([](){ SINRICPRO_PRINTF("Connected to SinricPro\r\n"); }); 
+  SinricPro.onDisconnected([](){ SINRICPRO_PRINTF("Disconnected from SinricPro\r\n"); });
   //SinricPro.restoreDeviceStates(true); // Uncomment to restore the last known state from the server.
   SinricPro.begin(APP_KEY, APP_SECRET);
 }
 
 // main setup function
 void setup() {
-  Serial.begin(BAUD_RATE); Serial.printf("\r\n\r\n");
+  Serial.begin(BAUD_RATE); SINRICPRO_PRINTF("\r\n\r\n");
   Wire.begin(I2C_SDA, I2C_SCL); //Initializing the I2C connection
 
   setupWiFi();

--- a/examples/temperaturesensor/HTU21D/HTU21D.ino
+++ b/examples/temperaturesensor/HTU21D/HTU21D.ino
@@ -30,6 +30,13 @@
   #include <ESP8266WiFi.h>
 #elif defined(ESP32) || defined(ARDUINO_ARCH_RP2040)
   #include <WiFi.h>
+#elif defined(ARDUINO_SAMD_MKRWIFI1010) || defined(ARDUINO_SAMD_NANO_33_IOT)
+  #include <WiFiNINA.h>
+#elif defined(ARDUINO_UNOWIFIR4) || defined(ARDUINO_MINIMA)
+  #include <WiFiS3.h>
+  #ifndef SINRICPRO_NOSSL
+    #define SINRICPRO_NOSSL
+  #endif
 #endiff
 
 #include "SinricPro.h"

--- a/library.json
+++ b/library.json
@@ -18,19 +18,17 @@
     }
   ],
   "homepage": "https://sinric.pro",
-  "version": "4.1.0",
+  "version": "5.0.0",
   "frameworks": "arduino",
-  "platforms": ["espressif8266", "espressif32", "raspberrypi"],
+  "platforms": ["espressif8266", "espressif32", "raspberrypi", "atmelsam", "renesas_uno"],
   "dependencies": [
     {
       "name": "ArduinoJson",
-      "version": "^7.0.3",
-      "platforms": ["espressif32", "espressif8266", "raspberrypi"]
+      "version": "^7.0.3"
     },
     {
       "name": "WebSockets",
-      "version": "^2.4.0",
-      "platforms": ["espressif32", "espressif8266", "raspberrypi"]
+      "version": "^2.4.0"
     }
   ],
   "examples": ["examples/*/*.ino", "examples/*/*/*.ino"],

--- a/library.properties
+++ b/library.properties
@@ -1,12 +1,12 @@
 name=SinricPro
-version=4.1.0
+version=5.0.0
 author=Boris Jaeger <sivar2311@gmail.com>
 maintainer=Boris Jaeger <sivar2311@gmail.com>
 sentence=Library for https://sinric.pro - simple way to connect your device to alexa
-paragraph=Simple way to control your IOT development boards like ESP8226 or ESP32 with Amazon Alexa or Google Home
+paragraph=Simple way to control your IOT development boards like ESP8266, ESP32, RP2040, Arduino UNO R4 WiFi, Arduino Nano 33 IoT, and MKR WiFi 1010 with Amazon Alexa or Google Home
 category=Communication
 url=https://github.com/sinricpro/esp8266-esp32-sdk/
-architectures=esp8266,esp32,rp2040
+architectures=esp8266,esp32,rp2040,samd,renesas_uno
 repository=https://github.com/sinricpro/esp8266-esp32-sdk.git
 license=CC-BY-SA
 depends=ArduinoJson (>=7.0.3), WebSockets (>=2.4.0)

--- a/src/Capabilities/CameraController.h
+++ b/src/Capabilities/CameraController.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#if !defined(ARDUINO_UNOWIFIR4) && !defined(ARDUINO_MINIMA) && !defined(ARDUINO_SAMD_MKRWIFI1010) && !defined(ARDUINO_SAMD_NANO_33_IOT)
+
 #include "../SinricProRequest.h"
 
 #include "../EventLimiter.h"
@@ -8,8 +10,8 @@
 
 #include <FS.h>
 
-#if defined(ESP32)  
-  #include <HTTPClient.h>  
+#if defined(ESP32)
+  #include <HTTPClient.h>
   #include <WiFiClientSecure.h>
 #endif
 
@@ -179,7 +181,9 @@ int CameraController<T>::sendMotion(fs::FS &fs, const char * path) {
 #endif
 }
 
-}  // namespace SINRICPRO_NAMESPACE 
+}  // namespace SINRICPRO_NAMESPACE
 
 template <typename T>
 using CameraController = SINRICPRO_NAMESPACE::CameraController<T>;
+
+#endif  // Exclude UNO R4, MINIMA, MKR WiFi 1010, and Nano 33 IoT

--- a/src/Capabilities/SettingController.h
+++ b/src/Capabilities/SettingController.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <variant>
-
 #include "../SinricProRequest.h"
 #include "../SinricProStrings.h"
 #include "../EventLimiter.h"
@@ -14,9 +12,77 @@ FSTR(SETTING, id);             // "id"
 FSTR(SETTING, value);          // "value"
 
 /**
- * @brief Variant type for setting values that can hold int, float, bool, or String
+ * @brief C++11-compatible variant type for setting values that can hold int, float, bool, or String
+ *
+ * This is a lightweight alternative to std::variant (C++17) for Arduino boards.
  */
-using SettingValue = std::variant<int, float, bool, String>;
+class SettingValue {
+  public:
+    enum class Type { INT, FLOAT, BOOL, STRING, NONE };
+
+    SettingValue() : type_(Type::NONE), int_val(0) {}
+    SettingValue(int val) : type_(Type::INT), int_val(val) {}
+    SettingValue(float val) : type_(Type::FLOAT), float_val(val) {}
+    SettingValue(bool val) : type_(Type::BOOL), bool_val(val) {}
+    SettingValue(const String& val) : type_(Type::STRING), string_val(val) {}
+    SettingValue(const char* val) : type_(Type::STRING), string_val(val) {}
+
+    SettingValue(const SettingValue& other) : type_(other.type_) {
+      switch (type_) {
+        case Type::INT:    int_val = other.int_val; break;
+        case Type::FLOAT:  float_val = other.float_val; break;
+        case Type::BOOL:   bool_val = other.bool_val; break;
+        case Type::STRING: string_val = other.string_val; break;
+        case Type::NONE:   break;
+      }
+    }
+
+    SettingValue& operator=(int val) { type_ = Type::INT; int_val = val; return *this; }
+    SettingValue& operator=(float val) { type_ = Type::FLOAT; float_val = val; return *this; }
+    SettingValue& operator=(bool val) { type_ = Type::BOOL; bool_val = val; return *this; }
+    SettingValue& operator=(const String& val) { type_ = Type::STRING; string_val = val; return *this; }
+    SettingValue& operator=(const char* val) { type_ = Type::STRING; string_val = val; return *this; }
+
+    SettingValue& operator=(const SettingValue& other) {
+      if (this != &other) {
+        type_ = other.type_;
+        switch (type_) {
+          case Type::INT:    int_val = other.int_val; break;
+          case Type::FLOAT:  float_val = other.float_val; break;
+          case Type::BOOL:   bool_val = other.bool_val; break;
+          case Type::STRING: string_val = other.string_val; break;
+          case Type::NONE:   break;
+        }
+      }
+      return *this;
+    }
+
+    template<typename T> bool holds() const;
+    template<typename T> T get() const;
+
+    Type type() const { return type_; }
+
+  private:
+    Type type_;
+    union {
+      int int_val;
+      float float_val;
+      bool bool_val;
+    };
+    String string_val;  // Can't be in union
+};
+
+// Template specializations for holds()
+template<> inline bool SettingValue::holds<int>() const { return type_ == Type::INT; }
+template<> inline bool SettingValue::holds<float>() const { return type_ == Type::FLOAT; }
+template<> inline bool SettingValue::holds<bool>() const { return type_ == Type::BOOL; }
+template<> inline bool SettingValue::holds<String>() const { return type_ == Type::STRING; }
+
+// Template specializations for get()
+template<> inline int SettingValue::get<int>() const { return int_val; }
+template<> inline float SettingValue::get<float>() const { return float_val; }
+template<> inline bool SettingValue::get<bool>() const { return bool_val; }
+template<> inline String SettingValue::get<String>() const { return string_val; }
 
 using SetSettingCallback = std::function<bool(const String&, const String&, SettingValue&)>;
 
@@ -67,14 +133,14 @@ bool SettingController<T>::sendSettingEvent(String settingId, SettingValue setti
   eventMessage[FSTR_SINRICPRO_scope] = FSTR_SINRICPRO_device;
   event_value[FSTR_SETTING_id] = settingId;
 
-  if (std::holds_alternative<int>(settingValue)) {
-    event_value[FSTR_SETTING_value] = std::get<int>(settingValue);
-  } else if (std::holds_alternative<float>(settingValue)) {
-    event_value[FSTR_SETTING_value] = std::get<float>(settingValue);
-  } else if (std::holds_alternative<bool>(settingValue)) {
-    event_value[FSTR_SETTING_value] = std::get<bool>(settingValue);
-  } else if (std::holds_alternative<String>(settingValue)) {
-    event_value[FSTR_SETTING_value] = std::get<String>(settingValue);
+  if (settingValue.holds<int>()) {
+    event_value[FSTR_SETTING_value] = settingValue.get<int>();
+  } else if (settingValue.holds<float>()) {
+    event_value[FSTR_SETTING_value] = settingValue.get<float>();
+  } else if (settingValue.holds<bool>()) {
+    event_value[FSTR_SETTING_value] = settingValue.get<bool>();
+  } else if (settingValue.holds<String>()) {
+    event_value[FSTR_SETTING_value] = settingValue.get<String>();
   }
 
   return device->sendEvent(eventMessage);
@@ -112,14 +178,14 @@ bool SettingController<T>::handleSettingController(SinricProRequest &request) {
 
     if (valueVariant.is<JsonObject>()) {
       request.response_value[FSTR_SETTING_value] = valueVariant;
-    } else if (std::holds_alternative<int>(settingValue)) {
-      request.response_value[FSTR_SETTING_value] = std::get<int>(settingValue);
-    } else if (std::holds_alternative<float>(settingValue)) {
-      request.response_value[FSTR_SETTING_value] = std::get<float>(settingValue);
-    } else if (std::holds_alternative<bool>(settingValue)) {
-      request.response_value[FSTR_SETTING_value] = std::get<bool>(settingValue);
-    } else if (std::holds_alternative<String>(settingValue)) {
-      request.response_value[FSTR_SETTING_value] = std::get<String>(settingValue);
+    } else if (settingValue.holds<int>()) {
+      request.response_value[FSTR_SETTING_value] = settingValue.get<int>();
+    } else if (settingValue.holds<float>()) {
+      request.response_value[FSTR_SETTING_value] = settingValue.get<float>();
+    } else if (settingValue.holds<bool>()) {
+      request.response_value[FSTR_SETTING_value] = settingValue.get<bool>();
+    } else if (settingValue.holds<String>()) {
+      request.response_value[FSTR_SETTING_value] = settingValue.get<String>();
     }
 
     return success;

--- a/src/EventLimiter.h
+++ b/src/EventLimiter.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "SinricProConfig.h"
+#include "SinricProDebug.h"
 #include "SinricProNamespace.h"
 
 namespace SINRICPRO_NAMESPACE {
@@ -45,7 +46,9 @@ EventLimiter::operator bool() {
   }
 
   fail_counter++;
-  if (fail_counter == fail_threshold) Serial.printf("WARNING: YOUR CODE SENDS EXCESSIVE EVENTS! EVENTS ARE NOW LIMITED BY AN ADDITIONAL DELAY OF %lu SECONDS. PLEASE CHECK YOUR CODE!\r\n", extra_distance / 1000);
+  if (fail_counter == fail_threshold) {
+    SINRICPRO_PRINTF("WARNING: YOUR CODE SENDS EXCESSIVE EVENTS! EVENTS ARE NOW LIMITED BY AN ADDITIONAL DELAY OF %lu SECONDS. PLEASE CHECK YOUR CODE!\r\n", extra_distance / 1000);
+  }
 
   return true;
 }

--- a/src/SinricPro.h
+++ b/src/SinricPro.h
@@ -233,10 +233,10 @@ void SinricProClass::begin(String appKey, String appSecret, String serverURL) {
     // - Must be 36 characters
     // - UUID format: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
     if (appKey.length() != 36) {
-        Serial.printf("[SinricPro:begin()]: Invalid App Key '%s' detected (Length: %d; Expected: 36). Initialization aborted! Please check your SinricPro credentials.\r\n", appKey.c_str(), appKey.length());
+        SINRICPRO_PRINTF("[SinricPro:begin()]: Invalid App Key '%s' detected (Length: %d; Expected: 36). Initialization aborted! Please check your SinricPro credentials.\r\n", appKey.c_str(), appKey.length());
         success = false;
     } else if (appKey.charAt(8) != '-' || appKey.charAt(13) != '-' || appKey.charAt(18) != '-' || appKey.charAt(23) != '-') {
-        Serial.printf("[SinricPro:begin()]: App Key '%s' is in an invalid format. Initialization aborted!\r\n", appKey.c_str());
+        SINRICPRO_PRINTF("[SinricPro:begin()]: App Key '%s' is in an invalid format. Initialization aborted!\r\n", appKey.c_str());
         success = false;
     }
 
@@ -244,11 +244,11 @@ void SinricProClass::begin(String appKey, String appSecret, String serverURL) {
     // - Must be 73 characters
     // - Double UUID format: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
     if (appSecret.length() != 73) {
-        Serial.printf("[SinricPro:begin()]: Invalid App Secret '%s' detected (Length: %d; Expected: 73). Initialization aborted! Please check your SinricPro credentials.\r\n", appSecret.c_str(), appSecret.length());
+        SINRICPRO_PRINTF("[SinricPro:begin()]: Invalid App Secret '%s' detected (Length: %d; Expected: 73). Initialization aborted! Please check your SinricPro credentials.\r\n", appSecret.c_str(), appSecret.length());
         success = false;
     } else if (appSecret.charAt(8) != '-' || appSecret.charAt(13) != '-' || appSecret.charAt(18) != '-' || appSecret.charAt(23) != '-' ||
                appSecret.charAt(36) != '-' || appSecret.charAt(45) != '-' || appSecret.charAt(50) != '-' || appSecret.charAt(55) != '-' || appSecret.charAt(60) != '-') {
-        Serial.printf("[SinricPro:begin()]: App Secret '%s' is in an invalid format. Initialization aborted!\r\n", appSecret.c_str());
+        SINRICPRO_PRINTF("[SinricPro:begin()]: App Secret '%s' is in an invalid format. Initialization aborted!\r\n", appSecret.c_str());
         success = false;
     }
 
@@ -271,7 +271,7 @@ DeviceType& SinricProClass::add(String deviceId) {
     // - Hexadecimal only (0-9, a-f, A-F)
     // - Format: 695b4624f6e5944047661b8a
     if (deviceId.length() != 24) {
-        Serial.printf("[SinricPro:add()]: Device Id \"%s\" is invalid (wrong length: expected 24, got %d)!! Please check your device-id!!\r\n", deviceId.c_str(), deviceId.length());
+        SINRICPRO_PRINTF("[SinricPro:add()]: Device Id \"%s\" is invalid (wrong length: expected 24, got %d)!! Please check your device-id!!\r\n", deviceId.c_str(), deviceId.length());
     }
 
     DeviceType* newDevice = new DeviceType(deviceId);

--- a/src/SinricPro.h
+++ b/src/SinricPro.h
@@ -60,7 +60,7 @@ using OTAUpdateCallbackHandler = std::function<bool(const String& url, int major
  * This callback is used to set a value for a specific setting identified by its ID.
  *
  * @param id The unique identifier of the setting to be set.
- * @param value The setting value as std::variant<int, float, bool, String>. Use std::holds_alternative<T>() and std::get<T>() to access.
+ * @param value The setting value as SettingValue (can hold int, float, bool, or String). Use value.holds<T>() and value.get<T>() to access.
  * @return bool Returns true if the setting was successfully updated, false otherwise.
  */
 using SetSettingCallbackHandler = std::function<bool(const String& id, SettingValue& value)>;
@@ -612,14 +612,14 @@ bool SinricProClass::sendSettingEvent(String settingId, SettingValue settingValu
     JsonObject event_value = payload[FSTR_SINRICPRO_value];
     event_value[FSTR_SETTING_id] = settingId;
 
-    if (std::holds_alternative<int>(settingValue)) {
-        event_value[FSTR_SETTING_value] = std::get<int>(settingValue);
-    } else if (std::holds_alternative<float>(settingValue)) {
-        event_value[FSTR_SETTING_value] = std::get<float>(settingValue);
-    } else if (std::holds_alternative<bool>(settingValue)) {
-        event_value[FSTR_SETTING_value] = std::get<bool>(settingValue);
-    } else if (std::holds_alternative<String>(settingValue)) {
-        event_value[FSTR_SETTING_value] = std::get<String>(settingValue);
+    if (settingValue.holds<int>()) {
+        event_value[FSTR_SETTING_value] = settingValue.get<int>();
+    } else if (settingValue.holds<float>()) {
+        event_value[FSTR_SETTING_value] = settingValue.get<float>();
+    } else if (settingValue.holds<bool>()) {
+        event_value[FSTR_SETTING_value] = settingValue.get<bool>();
+    } else if (settingValue.holds<String>()) {
+        event_value[FSTR_SETTING_value] = settingValue.get<String>();
     }
 
     sendMessage(eventMessage);

--- a/src/SinricProCrypto.h
+++ b/src/SinricProCrypto.h
@@ -1,0 +1,260 @@
+#pragma once
+
+/**
+ * @file SinricProCrypto.h
+ * @brief Portable SHA256 and HMAC-SHA256 implementation for boards without native crypto support
+ *
+ * This implementation is used for:
+ * - Arduino UNO R4 WiFi (Renesas RA4M1)
+ * - Arduino Nano 33 IoT (SAMD21)
+ * - Arduino MKR WiFi 1010 (SAMD21)
+ *
+ * ESP8266/RP2040 use BearSSL, ESP32 uses mbedtls (both built into their cores)
+ */
+
+#if defined(ARDUINO_SAMD_MKRWIFI1010) || defined(ARDUINO_SAMD_NANO_33_IOT) || defined(ARDUINO_UNOWIFIR4) || defined(ARDUINO_MINIMA)
+
+#include <Arduino.h>
+#include <stdint.h>
+#include <string.h>
+
+namespace SINRICPRO_CRYPTO {
+
+// SHA256 constants
+static const uint32_t SHA256_K[64] = {
+    0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
+    0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
+    0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+    0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
+    0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
+    0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+    0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+    0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2
+};
+
+// SHA256 helper macros
+#define ROTR(x, n) (((x) >> (n)) | ((x) << (32 - (n))))
+#define CH(x, y, z) (((x) & (y)) ^ (~(x) & (z)))
+#define MAJ(x, y, z) (((x) & (y)) ^ ((x) & (z)) ^ ((y) & (z)))
+#define EP0(x) (ROTR(x, 2) ^ ROTR(x, 13) ^ ROTR(x, 22))
+#define EP1(x) (ROTR(x, 6) ^ ROTR(x, 11) ^ ROTR(x, 25))
+#define SIG0(x) (ROTR(x, 7) ^ ROTR(x, 18) ^ ((x) >> 3))
+#define SIG1(x) (ROTR(x, 17) ^ ROTR(x, 19) ^ ((x) >> 10))
+
+class SHA256 {
+public:
+    static const size_t BLOCK_SIZE = 64;
+    static const size_t HASH_SIZE = 32;
+
+    SHA256() { reset(); }
+
+    void reset() {
+        state[0] = 0x6a09e667;
+        state[1] = 0xbb67ae85;
+        state[2] = 0x3c6ef372;
+        state[3] = 0xa54ff53a;
+        state[4] = 0x510e527f;
+        state[5] = 0x9b05688c;
+        state[6] = 0x1f83d9ab;
+        state[7] = 0x5be0cd19;
+        count = 0;
+        bufferOffset = 0;
+    }
+
+    void update(const uint8_t* data, size_t len) {
+        while (len--) {
+            buffer[bufferOffset++] = *data++;
+            count += 8;
+            if (bufferOffset == BLOCK_SIZE) {
+                processBlock();
+                bufferOffset = 0;
+            }
+        }
+    }
+
+    void update(const char* data, size_t len) {
+        update((const uint8_t*)data, len);
+    }
+
+    void finalize(uint8_t* hash) {
+        // Pad message
+        buffer[bufferOffset++] = 0x80;
+        if (bufferOffset > 56) {
+            while (bufferOffset < BLOCK_SIZE) buffer[bufferOffset++] = 0;
+            processBlock();
+            bufferOffset = 0;
+        }
+        while (bufferOffset < 56) buffer[bufferOffset++] = 0;
+
+        // Append length
+        for (int i = 7; i >= 0; i--) {
+            buffer[bufferOffset++] = (count >> (i * 8)) & 0xff;
+        }
+        processBlock();
+
+        // Output hash
+        for (int i = 0; i < 8; i++) {
+            hash[i * 4] = (state[i] >> 24) & 0xff;
+            hash[i * 4 + 1] = (state[i] >> 16) & 0xff;
+            hash[i * 4 + 2] = (state[i] >> 8) & 0xff;
+            hash[i * 4 + 3] = state[i] & 0xff;
+        }
+    }
+
+    static void hash(const uint8_t* data, size_t len, uint8_t* output) {
+        SHA256 ctx;
+        ctx.update(data, len);
+        ctx.finalize(output);
+    }
+
+private:
+    uint32_t state[8];
+    uint64_t count;
+    uint8_t buffer[BLOCK_SIZE];
+    size_t bufferOffset;
+
+    void processBlock() {
+        uint32_t w[64];
+        uint32_t a, b, c, d, e, f, g, h, t1, t2;
+
+        // Prepare message schedule
+        for (int i = 0; i < 16; i++) {
+            w[i] = ((uint32_t)buffer[i * 4] << 24) |
+                   ((uint32_t)buffer[i * 4 + 1] << 16) |
+                   ((uint32_t)buffer[i * 4 + 2] << 8) |
+                   ((uint32_t)buffer[i * 4 + 3]);
+        }
+        for (int i = 16; i < 64; i++) {
+            w[i] = SIG1(w[i - 2]) + w[i - 7] + SIG0(w[i - 15]) + w[i - 16];
+        }
+
+        // Initialize working variables
+        a = state[0]; b = state[1]; c = state[2]; d = state[3];
+        e = state[4]; f = state[5]; g = state[6]; h = state[7];
+
+        // Main loop
+        for (int i = 0; i < 64; i++) {
+            t1 = h + EP1(e) + CH(e, f, g) + SHA256_K[i] + w[i];
+            t2 = EP0(a) + MAJ(a, b, c);
+            h = g; g = f; f = e; e = d + t1;
+            d = c; c = b; b = a; a = t1 + t2;
+        }
+
+        // Update state
+        state[0] += a; state[1] += b; state[2] += c; state[3] += d;
+        state[4] += e; state[5] += f; state[6] += g; state[7] += h;
+    }
+};
+
+#undef ROTR
+#undef CH
+#undef MAJ
+#undef EP0
+#undef EP1
+#undef SIG0
+#undef SIG1
+
+class HMAC_SHA256 {
+public:
+    static const size_t HASH_SIZE = 32;
+    static const size_t BLOCK_SIZE = 64;
+
+    void init(const uint8_t* key, size_t keyLen) {
+        uint8_t keyBlock[BLOCK_SIZE];
+        memset(keyBlock, 0, BLOCK_SIZE);
+
+        if (keyLen > BLOCK_SIZE) {
+            SHA256::hash(key, keyLen, keyBlock);
+        } else {
+            memcpy(keyBlock, key, keyLen);
+        }
+
+        // Create inner and outer padded keys
+        for (size_t i = 0; i < BLOCK_SIZE; i++) {
+            ipad[i] = keyBlock[i] ^ 0x36;
+            opad[i] = keyBlock[i] ^ 0x5c;
+        }
+
+        // Start inner hash
+        innerCtx.reset();
+        innerCtx.update(ipad, BLOCK_SIZE);
+    }
+
+    void update(const uint8_t* data, size_t len) {
+        innerCtx.update(data, len);
+    }
+
+    void update(const char* data, size_t len) {
+        update((const uint8_t*)data, len);
+    }
+
+    void finalize(uint8_t* output) {
+        uint8_t innerHash[HASH_SIZE];
+        innerCtx.finalize(innerHash);
+
+        // Outer hash
+        SHA256 outerCtx;
+        outerCtx.update(opad, BLOCK_SIZE);
+        outerCtx.update(innerHash, HASH_SIZE);
+        outerCtx.finalize(output);
+    }
+
+    static void compute(const uint8_t* key, size_t keyLen,
+                        const uint8_t* data, size_t dataLen,
+                        uint8_t* output) {
+        HMAC_SHA256 ctx;
+        ctx.init(key, keyLen);
+        ctx.update(data, dataLen);
+        ctx.finalize(output);
+    }
+
+private:
+    SHA256 innerCtx;
+    uint8_t ipad[BLOCK_SIZE];
+    uint8_t opad[BLOCK_SIZE];
+};
+
+// Base64 encoding for platforms without libb64
+class Base64 {
+public:
+    static size_t encodedLength(size_t inputLen) {
+        return ((inputLen + 2) / 3) * 4 + 1;
+    }
+
+    static size_t encode(const uint8_t* input, size_t inputLen, char* output) {
+        static const char base64Chars[] =
+            "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+        size_t outputLen = 0;
+        size_t i = 0;
+
+        while (i < inputLen) {
+            uint32_t octet_a = i < inputLen ? input[i++] : 0;
+            uint32_t octet_b = i < inputLen ? input[i++] : 0;
+            uint32_t octet_c = i < inputLen ? input[i++] : 0;
+
+            uint32_t triple = (octet_a << 16) + (octet_b << 8) + octet_c;
+
+            output[outputLen++] = base64Chars[(triple >> 18) & 0x3F];
+            output[outputLen++] = base64Chars[(triple >> 12) & 0x3F];
+            output[outputLen++] = base64Chars[(triple >> 6) & 0x3F];
+            output[outputLen++] = base64Chars[triple & 0x3F];
+        }
+
+        // Add padding
+        size_t mod = inputLen % 3;
+        if (mod == 1) {
+            output[outputLen - 1] = '=';
+            output[outputLen - 2] = '=';
+        } else if (mod == 2) {
+            output[outputLen - 1] = '=';
+        }
+
+        output[outputLen] = '\0';
+        return outputLen;
+    }
+};
+
+} // namespace SINRICPRO_CRYPTO
+
+#endif // ARDUINO_SAMD_* || ARDUINO_UNOWIFIR4 || ARDUINO_MINIMA

--- a/src/SinricProDebug.h
+++ b/src/SinricProDebug.h
@@ -7,9 +7,45 @@
 
 #pragma once
 
+#include <Arduino.h>
+#include <stdarg.h>
+
+// Check if Serial.printf is available
+// Arduino UNO R4 WiFi, Nano 33 IoT, MKR WiFi 1010 don't have Serial.printf
+#if defined(ARDUINO_UNOWIFIR4) || defined(ARDUINO_MINIMA) || defined(ARDUINO_SAMD_MKRWIFI1010) || defined(ARDUINO_SAMD_NANO_33_IOT)
+  #define SINRICPRO_NO_SERIAL_PRINTF
+#endif
+
+/**
+ * @brief Portable printf function that works on all Arduino boards
+ *
+ * Use this instead of Serial.printf() for cross-platform compatibility.
+ * Works on ESP8266, ESP32, RP2040, Arduino UNO R4 WiFi, Nano 33 IoT, MKR WiFi 1010
+ *
+ * @param format printf-style format string
+ * @param ... variable arguments
+ */
+inline void SINRICPRO_PRINTF(const char* format, ...) {
+  char buf[256];
+  va_list args;
+  va_start(args, format);
+  vsnprintf(buf, sizeof(buf), format, args);
+  va_end(args);
+  Serial.print(buf);
+}
+
 #ifndef NODEBUG_SINRIC
 #ifdef DEBUG_ESP_PORT
-#define DEBUG_SINRIC(...) DEBUG_ESP_PORT.printf( __VA_ARGS__ )
+  #ifdef SINRICPRO_NO_SERIAL_PRINTF
+    // For boards without printf, use portable version
+    #define DEBUG_SINRIC(...) do { \
+      char _dbg_buf[256]; \
+      snprintf(_dbg_buf, sizeof(_dbg_buf), __VA_ARGS__); \
+      DEBUG_ESP_PORT.print(_dbg_buf); \
+    } while(0)
+  #else
+    #define DEBUG_SINRIC(...) DEBUG_ESP_PORT.printf( __VA_ARGS__ )
+  #endif
 #else
 //#define DEBUG_WEBSOCKETS(...) os_printf( __VA_ARGS__ )
 #endif

--- a/src/SinricProDebug.h
+++ b/src/SinricProDebug.h
@@ -17,6 +17,17 @@
 #endif
 
 /**
+ * @brief Buffer size for SINRICPRO_PRINTF output
+ *
+ * Define SINRICPRO_PRINTF_BUFFER_SIZE before including SinricPro headers
+ * to customize the buffer size for memory-constrained boards.
+ * Default is 256 bytes.
+ */
+#ifndef SINRICPRO_PRINTF_BUFFER_SIZE
+  #define SINRICPRO_PRINTF_BUFFER_SIZE 256
+#endif
+
+/**
  * @brief Portable printf function that works on all Arduino boards
  *
  * Use this instead of Serial.printf() for cross-platform compatibility.
@@ -26,7 +37,7 @@
  * @param ... variable arguments
  */
 inline void SINRICPRO_PRINTF(const char* format, ...) {
-  char buf[256];
+  char buf[SINRICPRO_PRINTF_BUFFER_SIZE];
   va_list args;
   va_start(args, format);
   vsnprintf(buf, sizeof(buf), format, args);
@@ -39,7 +50,7 @@ inline void SINRICPRO_PRINTF(const char* format, ...) {
   #ifdef SINRICPRO_NO_SERIAL_PRINTF
     // For boards without printf, use portable version
     #define DEBUG_SINRIC(...) do { \
-      char _dbg_buf[256]; \
+      char _dbg_buf[SINRICPRO_PRINTF_BUFFER_SIZE]; \
       snprintf(_dbg_buf, sizeof(_dbg_buf), __VA_ARGS__); \
       DEBUG_ESP_PORT.print(_dbg_buf); \
     } while(0)

--- a/src/SinricProModuleCommandHandler.h
+++ b/src/SinricProModuleCommandHandler.h
@@ -102,14 +102,14 @@ bool SinricProModuleCommandHandler::handleRequest(SinricProRequest &request) {
 
     if (valueVariant.is<JsonObject>()) {
       request.response_value[FSTR_SETTINGS_value] = valueVariant;
-    } else if (std::holds_alternative<int>(settingValue)) {
-      request.response_value[FSTR_SETTINGS_value] = std::get<int>(settingValue);
-    } else if (std::holds_alternative<float>(settingValue)) {
-      request.response_value[FSTR_SETTINGS_value] = std::get<float>(settingValue);
-    } else if (std::holds_alternative<bool>(settingValue)) {
-      request.response_value[FSTR_SETTINGS_value] = std::get<bool>(settingValue);
-    } else if (std::holds_alternative<String>(settingValue)) {
-      request.response_value[FSTR_SETTINGS_value] = std::get<String>(settingValue);
+    } else if (settingValue.holds<int>()) {
+      request.response_value[FSTR_SETTINGS_value] = settingValue.get<int>();
+    } else if (settingValue.holds<float>()) {
+      request.response_value[FSTR_SETTINGS_value] = settingValue.get<float>();
+    } else if (settingValue.holds<bool>()) {
+      request.response_value[FSTR_SETTINGS_value] = settingValue.get<bool>();
+    } else if (settingValue.holds<String>()) {
+      request.response_value[FSTR_SETTINGS_value] = settingValue.get<String>();
     }
 
     return success;

--- a/src/SinricProSignature.cpp
+++ b/src/SinricProSignature.cpp
@@ -16,26 +16,27 @@
   #include "mbedtls/md.h"
 #endif
 #if defined(ARDUINO_SAMD_MKRWIFI1010) || defined(ARDUINO_SAMD_NANO_33_IOT) || defined(ARDUINO_UNOWIFIR4) || defined(ARDUINO_MINIMA)
-  #include <bearssl/bearssl_hmac.h>
-#endif
+  #include "SinricProCrypto.h"
+#else
   #include <libb64/cencode.h>
+#endif
   
 #include "SinricProNamespace.h"
 namespace SINRICPRO_NAMESPACE {
 
 String HMACbase64(const String &message, const String &key) {
   byte hmacResult[32];
-#if defined(ESP8266) || defined(ARDUINO_ARCH_RP2040) || defined(ARDUINO_SAMD_MKRWIFI1010) || defined(ARDUINO_SAMD_NANO_33_IOT) || defined(ARDUINO_UNOWIFIR4) || defined(ARDUINO_MINIMA)
-  br_hmac_key_context keyContext; // Holds general HMAC info
-  br_hmac_context hmacContext;    // Holds general HMAC info + specific info for the current operation
+#if defined(ESP8266) || defined(ARDUINO_ARCH_RP2040)
+  // BearSSL implementation (built into ESP8266/RP2040 cores)
+  br_hmac_key_context keyContext;
+  br_hmac_context hmacContext;
 
   br_hmac_key_init(&keyContext, &br_sha256_vtable, key.c_str(), key.length());
   br_hmac_init(&hmacContext, &keyContext, 32);
   br_hmac_update(&hmacContext, message.c_str(), message.length());
   br_hmac_out(&hmacContext, hmacResult);
-#endif
-
-#if defined(ESP32)
+#elif defined(ESP32)
+  // mbedtls implementation (built into ESP32 core)
   mbedtls_md_context_t ctx;
   mbedtls_md_type_t md_type = MBEDTLS_MD_SHA256;
 
@@ -45,18 +46,32 @@ String HMACbase64(const String &message, const String &key) {
   mbedtls_md_hmac_update(&ctx, (const unsigned char*) message.c_str(), message.length());
   mbedtls_md_hmac_finish(&ctx, hmacResult);
   mbedtls_md_free(&ctx);
+#elif defined(ARDUINO_SAMD_MKRWIFI1010) || defined(ARDUINO_SAMD_NANO_33_IOT) || defined(ARDUINO_UNOWIFIR4) || defined(ARDUINO_MINIMA)
+  // Portable HMAC-SHA256 implementation for Arduino boards
+  SINRICPRO_CRYPTO::HMAC_SHA256::compute(
+    (const uint8_t*)key.c_str(), key.length(),
+    (const uint8_t*)message.c_str(), message.length(),
+    hmacResult
+  );
 #endif
 
-
+  // Base64 encode the HMAC result
+#if defined(ARDUINO_SAMD_MKRWIFI1010) || defined(ARDUINO_SAMD_NANO_33_IOT) || defined(ARDUINO_UNOWIFIR4) || defined(ARDUINO_MINIMA)
+  // Use portable base64 encoding for Arduino boards
+  char base64encodedHMAC[SINRICPRO_CRYPTO::Base64::encodedLength(32)];
+  SINRICPRO_CRYPTO::Base64::encode(hmacResult, 32, base64encodedHMAC);
+#else
+  // Use libb64 for ESP8266/ESP32/RP2040
   base64_encodestate _state;
   base64_init_encodestate(&_state);
 #if defined(base64_encode_expected_len_nonewlines)
   _state.stepsnewline = -1;
-#endif  
+#endif
   char base64encodedHMAC[base64_encode_expected_len(32) + 1];
   int len = base64_encode_block((const char *)hmacResult, 32, base64encodedHMAC, &_state);
   base64_encode_blockend((base64encodedHMAC + len), &_state);
-  
+#endif
+
   return String { base64encodedHMAC };
 }
 

--- a/src/SinricProSignature.cpp
+++ b/src/SinricProSignature.cpp
@@ -53,6 +53,8 @@ String HMACbase64(const String &message, const String &key) {
     (const uint8_t*)message.c_str(), message.length(),
     hmacResult
   );
+#else
+  #error "Unsupported platform: No HMAC-SHA256 implementation available. Please add support for your platform."
 #endif
 
   // Base64 encode the HMAC result

--- a/src/SinricProSignature.cpp
+++ b/src/SinricProSignature.cpp
@@ -9,11 +9,14 @@
 #include <ArduinoJson.h>
 #include "SinricProSignature.h"
 
-#if defined (ESP8266) || defined(ARDUINO_ARCH_RP2040)
+#if defined(ESP8266) || defined(ARDUINO_ARCH_RP2040)
   #include <bearssl/bearssl_hmac.h>
 #endif
-#if defined (ESP32)
+#if defined(ESP32)
   #include "mbedtls/md.h"
+#endif
+#if defined(ARDUINO_SAMD_MKRWIFI1010) || defined(ARDUINO_SAMD_NANO_33_IOT) || defined(ARDUINO_UNOWIFIR4) || defined(ARDUINO_MINIMA)
+  #include <bearssl/bearssl_hmac.h>
 #endif
   #include <libb64/cencode.h>
   
@@ -22,7 +25,7 @@ namespace SINRICPRO_NAMESPACE {
 
 String HMACbase64(const String &message, const String &key) {
   byte hmacResult[32];
-#if defined(ESP8266) || defined(ARDUINO_ARCH_RP2040)
+#if defined(ESP8266) || defined(ARDUINO_ARCH_RP2040) || defined(ARDUINO_SAMD_MKRWIFI1010) || defined(ARDUINO_SAMD_NANO_33_IOT) || defined(ARDUINO_UNOWIFIR4) || defined(ARDUINO_MINIMA)
   br_hmac_key_context keyContext; // Holds general HMAC info
   br_hmac_context hmacContext;    // Holds general HMAC info + specific info for the current operation
 

--- a/src/SinricProWebsocket.h
+++ b/src/SinricProWebsocket.h
@@ -11,6 +11,13 @@
     #include <ESP8266WiFi.h>
 #elif defined(ESP32) || defined(ARDUINO_ARCH_RP2040)
     #include <WiFi.h>
+#elif defined(ARDUINO_SAMD_MKRWIFI1010) || defined(ARDUINO_SAMD_NANO_33_IOT)
+    #include <WiFiNINA.h>
+#elif defined(ARDUINO_UNOWIFIR4) || defined(ARDUINO_MINIMA)
+    #include <WiFiS3.h>
+    #ifndef SINRICPRO_NOSSL
+        #define SINRICPRO_NOSSL
+    #endif
 #endif
 
 #include <ArduinoJson.h>
@@ -92,13 +99,39 @@ void WebsocketListener::setExtraHeaders() {
     const char* platform = "ESP32";
 #elif defined(ARDUINO_ARCH_RP2040)
     const char* platform = "RP2040";
+#elif defined(ARDUINO_UNOWIFIR4)
+    const char* platform = "UNOWIFIR4";
+#elif defined(ARDUINO_MINIMA)
+    const char* platform = "MINIMA";
+#elif defined(ARDUINO_SAMD_MKRWIFI1010)
+    const char* platform = "MKRWIFI1010";
+#elif defined(ARDUINO_SAMD_NANO_33_IOT)
+    const char* platform = "NANO_33_IOT";
+#else
+    const char* platform = "UNKNOWN";
+#endif
+
+#if defined(ARDUINO_SAMD_MKRWIFI1010) || defined(ARDUINO_SAMD_NANO_33_IOT)
+    // WiFiNINA returns byte array, format as string
+    auto formatMacAddress = []() -> String {
+        byte mac[6];
+        WiFi.macAddress(mac);
+        char macStr[18];
+        snprintf(macStr, sizeof(macStr), "%02X:%02X:%02X:%02X:%02X:%02X",
+                 mac[5], mac[4], mac[3], mac[2], mac[1], mac[0]);
+        return String(macStr);
+    };
 #endif
 
     String headers = "appkey:" + appKey;
     headers += "\r\ndeviceids:" + deviceIds;
     headers += "\r\nrestoredevicestates:" + String(restoreDeviceStates ? "true" : "false");
     headers += "\r\nip:" + WiFi.localIP().toString();
+#if defined(ARDUINO_SAMD_MKRWIFI1010) || defined(ARDUINO_SAMD_NANO_33_IOT)
+    headers += "\r\nmac:" + formatMacAddress();
+#else
     headers += "\r\nmac:" + WiFi.macAddress();
+#endif
     headers += "\r\nplatform:" + String(platform);
     headers += "\r\nSDKVersion:" + String(SINRICPRO_VERSION);
 

--- a/src/SinricProWebsocket.h
+++ b/src/SinricProWebsocket.h
@@ -111,8 +111,8 @@ void WebsocketListener::setExtraHeaders() {
     const char* platform = "UNKNOWN";
 #endif
 
-#if defined(ARDUINO_SAMD_MKRWIFI1010) || defined(ARDUINO_SAMD_NANO_33_IOT)
-    // WiFiNINA returns byte array, format as string
+#if defined(ARDUINO_SAMD_MKRWIFI1010) || defined(ARDUINO_SAMD_NANO_33_IOT) || defined(ARDUINO_UNOWIFIR4) || defined(ARDUINO_MINIMA)
+    // WiFiNINA and WiFiS3 return byte array, format as string
     auto formatMacAddress = []() -> String {
         byte mac[6];
         WiFi.macAddress(mac);
@@ -127,7 +127,7 @@ void WebsocketListener::setExtraHeaders() {
     headers += "\r\ndeviceids:" + deviceIds;
     headers += "\r\nrestoredevicestates:" + String(restoreDeviceStates ? "true" : "false");
     headers += "\r\nip:" + WiFi.localIP().toString();
-#if defined(ARDUINO_SAMD_MKRWIFI1010) || defined(ARDUINO_SAMD_NANO_33_IOT)
+#if defined(ARDUINO_SAMD_MKRWIFI1010) || defined(ARDUINO_SAMD_NANO_33_IOT) || defined(ARDUINO_UNOWIFIR4) || defined(ARDUINO_MINIMA)
     headers += "\r\nmac:" + formatMacAddress();
 #else
     headers += "\r\nmac:" + WiFi.macAddress();

--- a/src/SinricProWebsocket.h
+++ b/src/SinricProWebsocket.h
@@ -112,7 +112,9 @@ void WebsocketListener::setExtraHeaders() {
 #endif
 
 #if defined(ARDUINO_SAMD_MKRWIFI1010) || defined(ARDUINO_SAMD_NANO_33_IOT) || defined(ARDUINO_UNOWIFIR4) || defined(ARDUINO_MINIMA)
-    // WiFiNINA and WiFiS3 return byte array, format as string
+    // WiFiNINA and WiFiS3 return MAC address as byte array in network order (LSB first).
+    // mac[0] = LSB, mac[5] = MSB. We format it in standard notation (MSB:...:LSB).
+    // This matches the format returned by ESP8266/ESP32 WiFi.macAddress() string.
     auto formatMacAddress = []() -> String {
         byte mac[6];
         WiFi.macAddress(mac);

--- a/src/SinricProWebsocket.h
+++ b/src/SinricProWebsocket.h
@@ -111,6 +111,10 @@ void WebsocketListener::setExtraHeaders() {
     const char* platform = "UNKNOWN";
 #endif
 
+    String headers = "appkey:" + appKey;
+    headers += "\r\ndeviceids:" + deviceIds;
+    headers += "\r\nrestoredevicestates:" + String(restoreDeviceStates ? "true" : "false");
+    headers += "\r\nip:" + WiFi.localIP().toString();
 #if defined(ARDUINO_SAMD_MKRWIFI1010) || defined(ARDUINO_SAMD_NANO_33_IOT) || defined(ARDUINO_UNOWIFIR4) || defined(ARDUINO_MINIMA)
     // WiFiNINA and WiFiS3 return MAC address as byte array in network order (LSB first).
     // mac[0] = LSB, mac[5] = MSB. We format it in standard notation (MSB:...:LSB).
@@ -123,13 +127,6 @@ void WebsocketListener::setExtraHeaders() {
                  mac[5], mac[4], mac[3], mac[2], mac[1], mac[0]);
         return String(macStr);
     };
-#endif
-
-    String headers = "appkey:" + appKey;
-    headers += "\r\ndeviceids:" + deviceIds;
-    headers += "\r\nrestoredevicestates:" + String(restoreDeviceStates ? "true" : "false");
-    headers += "\r\nip:" + WiFi.localIP().toString();
-#if defined(ARDUINO_SAMD_MKRWIFI1010) || defined(ARDUINO_SAMD_NANO_33_IOT) || defined(ARDUINO_UNOWIFIR4) || defined(ARDUINO_MINIMA)
     headers += "\r\nmac:" + formatMacAddress();
 #else
     headers += "\r\nmac:" + WiFi.macAddress();


### PR DESCRIPTION
1. Bring additional boards support to `arduinoWebSockets` via https://github.com/Links2004/arduinoWebSockets/pull/901
1. Added `SINRICPRO_PRINTF` to support `Serial.printf` since no `printf` ref:  https://github.com/arduino/ArduinoCore-renesas/issues/351
2. Bring back `SettingValue` to support C++ 11 compatibility
3. Crypto support for additional boards via (SinricProCrypto.h) 
